### PR TITLE
unique download file neames for .ics

### DIFF
--- a/collectivo/app/components/shiftsDashboard/DownloadIcsButton.vue
+++ b/collectivo/app/components/shiftsDashboard/DownloadIcsButton.vue
@@ -105,7 +105,11 @@ END:VCALENDAR`;
 
   const link = document.createElement("a");
   link.href = url;
-  link.download = "event.ics";
+  const safeShiftName = shift.shifts_name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-") // replace special chars with "-"
+    .replace(/(^-|-$)/g, ""); // remove leading/trailing dashes
+  link.download = `mila-shift-${safeShiftName}-${nextOccurrenceStart.toFormat("yyyyMMdd-HHmm")}-${assignment.id}.ics`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);


### PR DESCRIPTION
Da Browser oft anbieten, eine Datei mit dem gleichen Namen nicht nochmal herunterzuladen, sollten unsere Kalender-Dateien nur dann gleiche Namen haben, wenn sie auch die gleichen Kalendereinträge repräsenteiren.