### PR TITLE
enable keycloak in production with externalized database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ KEYCLOAK_REALM = "collectivo"
 KEYCLOAK_ADMIN = 'admin@example.com'
 KEYCLOAK_ADMIN_PASSWORD = 'admin'
 KEYCLOAK_DB_PASSWORD = 'changeme'
+# Required for production: hostname of the external Keycloak PostgreSQL database
+# For local keycloak testing: set to "keycloak-db"
+KEYCLOAK_DB_HOST = ""
 KEYCLOAK_ADMIN_CLIENT = "admin-cli"
 KEYCLOAK_ADMIN_SECRET = "**********"
 KEYCLOAK_DIRECTUS_CLIENT = 'directus'

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ The dev setup runs without keycloak. To test keycloak integration, run both comp
 
 - In `collectivo/.env`, set `NUXT_PUBLIC_USE_KEYCLOAK = "true"`
 - In `.env`, set `DIRECTUS_AUTH_PROVIDERS` to `keycloak`
+- In `.env`, set `KEYCLOAK_DB_HOST = "keycloak-db"`
 - Add the following to your etc/hosts file ([here is a guide](https://www.howtogeek.com/27350/beginner-geek-how-to-edit-your-hosts-file/)): `127.0.0.1 keycloak`
-- Run `docker compose -f docker-compose.production.yml up -d keycloak keycloak-db`
+- Run `docker compose up -d keycloak-db`
+- Run `docker compose -f docker-compose.production.yml up -d keycloak`
 
 Login credentials for directus admin without keycloak:
 
@@ -103,11 +105,13 @@ Login credentials for keycloak admin UI:
 - Create a sync lock file `"/directus/uploads/sync.lock"`
 - Provision an external PostgreSQL database (with PostGIS extension) for Directus
 - Provision an external MariaDB database for Habidat
+- Provision an external PostgreSQL database for Keycloak
 - Set .env vars
   - Generate secure secrets, keys, and passwords
   - Set `DIRECTUS_DB_HOST` to the hostname of the external Directus database
   - Set `HABIDAT_DB_HOST` to the hostname of the external Habidat database
-  - Remove variable `KEYCLOAK_COMMAND`
+  - Set `KEYCLOAK_DB_HOST` to the hostname of the external Keycloak database
+  - Remove variable `KEYCLOAK_COMMAND` (absence triggers production mode)
 - [Set up a reverse proxy](https://www.linode.com/docs/guides/using-nginx-proxy-manager/) with a docker network called `proxiable`
 - Set the following [custom Nginx configuration](https://stackoverflow.com/questions/56126864) for Keycloak
   ```

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -5,12 +5,12 @@ services:
       dockerfile: Dockerfile
     extra_hosts:
       - "host.docker.internal:host-gateway"
- #   depends_on:
-      # keycloak:
-      #   condition: service_healthy
+    depends_on:
+      keycloak:
+        condition: service_healthy
     volumes:
       - directus-uploads:/directus/uploads
-    # entrypoint: ["/entrypoint.sh"]
+    entrypoint: ["/entrypoint.sh"]
     restart: unless-stopped
     networks:
       - default
@@ -21,7 +21,7 @@ services:
 
       ADMIN_EMAIL: ${DIRECTUS_ADMIN_EMAIL}
       ADMIN_PASSWORD: ${DIRECTUS_ADMIN_PASSWORD}
-      # ADMIN_TOKEN: ${DIRECTUS_ADMIN_TOKEN}
+      ADMIN_TOKEN: ${DIRECTUS_ADMIN_TOKEN}
 
       DB_CLIENT: "pg"
       DB_HOST: ${DIRECTUS_DB_HOST}
@@ -30,16 +30,16 @@ services:
       DB_USER: "directus"
       DB_PASSWORD: ${DIRECTUS_DB_PASSWORD}
 
-      # AUTH_PROVIDERS: "keycloak"
-      # AUTH_KEYCLOAK_DRIVER: "openid"
-      # AUTH_KEYCLOAK_CLIENT_ID: ${KEYCLOAK_DIRECTUS_CLIENT}
-      # AUTH_KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_DIRECTUS_SECRET}
-      # AUTH_KEYCLOAK_ISSUER_URL: "${KEYCLOAK_URL}/realms/collectivo/.well-known/openid-configuration"
-      # AUTH_KEYCLOAK_IDENTIFIER_KEY: "email"
-      # AUTH_KEYCLOAK_ALLOW_PUBLIC_REGISTRATION: "true"
-      # AUTH_KEYCLOAK_REDIRECT_ALLOW_LIST: ${COLLECTIVO_URL}
+      AUTH_PROVIDERS: "keycloak"
+      AUTH_KEYCLOAK_DRIVER: "openid"
+      AUTH_KEYCLOAK_CLIENT_ID: ${KEYCLOAK_DIRECTUS_CLIENT}
+      AUTH_KEYCLOAK_CLIENT_SECRET: ${KEYCLOAK_DIRECTUS_SECRET}
+      AUTH_KEYCLOAK_ISSUER_URL: "${KEYCLOAK_URL}/realms/collectivo/.well-known/openid-configuration"
+      AUTH_KEYCLOAK_IDENTIFIER_KEY: "email"
+      AUTH_KEYCLOAK_ALLOW_PUBLIC_REGISTRATION: "true"
+      AUTH_KEYCLOAK_REDIRECT_ALLOW_LIST: ${COLLECTIVO_URL}
 
-      # SESSION_COOKIE_DOMAIN: "${DIRECTUS_SESSION_COOKIE_DOMAIN}"
+      SESSION_COOKIE_DOMAIN: "${DIRECTUS_SESSION_COOKIE_DOMAIN}"
       SESSION_COOKIE_SECURE: "true"
       SESSION_COOKIE_SAME_SITE: "lax"
 
@@ -57,9 +57,9 @@ services:
   collectivo:
     build: ./
     restart: unless-stopped
-    # depends_on:
-    #   - directus
-    #   - keycloak
+    depends_on:
+      - directus
+      - keycloak
     environment:
       NUXT_API_TOKEN: ${COLLECTIVO_API_TOKEN}
       NUXT_CHECKIN_TOKEN: ${COLLECTIVO_CHECKIN_TOKEN}
@@ -91,54 +91,38 @@ services:
       NUXT_PUBLIC_LOTZAPP_SORTIMENT_URL: ${LOTZAPP_SORTIMENT_URL}
       NUXT_PUBLIC_ANNY_LOGIN_URL: ${ANNY_LOGIN_URL}
 
-  # keycloak:
-  #   build: ./keycloak
-
-  #   environment:
-  #     KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
-  #     KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
-  #     KEYCLOAK_FRONTEND_URL: ${KEYCLOAK_URL}
-  #     KC_DB_USERNAME: keycloak
-  #     KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
-  #     KC_DB_SCHEMA: public
-  #     KC_DB_URL_DATABASE: "keycloak"
-  #     KC_DB_URL_HOST: "keycloak-db"
-  #     KC_DB_URL_PORT: 5432
-  #     KC_HOSTNAME: ${KEYCLOAK_DOMAIN}
-  #   command: ${KEYCLOAK_COMMAND:-}
-  #   healthcheck:
-  #     test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
-  #     interval: 5s
-  #     timeout: 5s
-  #     retries: 20
-  #   volumes:
-  #     - ./keycloak/themes/collectivo:/opt/keycloak/themes/collectivo
-  #     - ./keycloak/import:/opt/keycloak/data/import:ro
-  #     - ./keycloak/export:/tmp/export
-  #   restart: unless-stopped
-  #   depends_on:
-  #     - keycloak-db
-
-  # keycloak-db:
-  #   image: postgres:14-alpine
-
-  #   volumes:
-  #     - keycloak-db-data:/var/lib/postgresql/data
-  #     - ./keycloak-db-backups:/backups
-  #   restart: unless-stopped
-  #   environment:
-  #     POSTGRES_DB: keycloak
-  #     POSTGRES_USER: keycloak
-  #     POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
-  #   healthcheck:
-  #     test: ["CMD-SHELL", "pg_isready"]
-  #     interval: 10s
-  #     timeout: 5s
-  #     retries: 5
+  keycloak:
+    build: ./keycloak
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KEYCLOAK_FRONTEND_URL: ${KEYCLOAK_URL}
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
+      KC_DB_SCHEMA: public
+      KC_DB_URL_DATABASE: "keycloak"
+      KC_DB_URL_HOST: ${KEYCLOAK_DB_HOST}
+      KC_DB_URL_PORT: 5432
+      KC_HOSTNAME: ${KEYCLOAK_DOMAIN}
+    command: ${KEYCLOAK_COMMAND:-}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - ./keycloak/themes/collectivo:/opt/keycloak/themes/collectivo
+    restart: unless-stopped
+    networks:
+      - default
+      - dokploy-network
 
   habidat:
     image: habidat/direktkredit:1.5
     restart: unless-stopped
+    depends_on:
+      keycloak:
+        condition: service_healthy
     volumes:
       - habidat-config:/habidat/config/
       - habidat-files:/habidat/public/files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,5 +49,21 @@ services:
       POSTGRES_USER: "directus"
       POSTGRES_PASSWORD: ${DIRECTUS_DB_PASSWORD}
 
+  keycloak-db:
+    image: postgres:14-alpine
+    volumes:
+      - keycloak-db-data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      POSTGRES_DB: keycloak
+      POSTGRES_USER: keycloak
+      POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
+
 volumes:
   directus-db-data:
+  keycloak-db-data:


### PR DESCRIPTION
- Uncomment and wire up the keycloak service in docker-compose.production.yml, switching KC_DB_URL_HOST from hardcoded "keycloak-db" to ${KEYCLOAK_DB_HOST}
- Re-enable depends_on keycloak for directus and collectivo; add it to habidat
- Re-enable Directus entrypoint, ADMIN_TOKEN, Keycloak auth config, and SESSION_COOKIE_DOMAIN
- Add keycloak-db to docker-compose.yml for local Keycloak testing
- Document external Keycloak DB in README and .env.example