### PR TITLE
add nextcloud

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ KEYCLOAK_NUXT_CLIENT = 'nuxt'
 # Remove this variable entirely for production
 KEYCLOAK_COMMAND = 'start-dev --import-realm --health-enabled true'
 
+NEXTCLOUD_DB_PASSWORD = 'changeme'
+NEXTCLOUD_DB_ROOT_PASSWORD = 'changeme'
+
 LOTZAPP_MANDANT = ""
 LOTZAPP_SEPA_ID = ""
 LOTZAPP_TRANSFER_ID = ""

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ node_modules
 
 # directus-sync generated API specs (informational only, not used by push)
 directus-config/specs/
+
+# Nextcloud
+nextcloud_data/
+nextcloud_db_data/

--- a/README.md
+++ b/README.md
@@ -7,12 +7,27 @@ Member plattform of [MILA Mitmach-Supermarkt e.G.](https://www.mila.wien/).
 - Install Docker, nodejs, and PNPM
 - Clone this repository
 
-- Create .env file with `cp .env.example .env`
-- Run `docker compose up -d` and wait for directus to be ready
-- Run `docker compose exec -u root directus-dev chown -R node:node /directus/extensions /directus/uploads`
-- Run `npx directus-sync push` to apply data schema
-- Install packages with `pnpm i`
-- Start dev server with `pnpm dev`
+- Create .env file:
+  ```sh
+  cp .env.example .env
+  ```
+- Start the containers and wait for directus to be ready:
+  ```sh
+  docker compose up -d
+  ```
+- Give directus access to directories (runs as user `node`):
+  ```sh
+  docker compose exec -u root directus-dev chown -R node:node /directus/extensions /directus/uploads
+  ```
+- Apply data schema:
+  ```sh
+  npx directus-sync push
+  ```
+- Install packages and start collectivo:
+  ```sh
+  pnpm i
+  pnpm dev
+  ```
 - Go to http://localhost:3000 and click on "Seed example data" or run `pnpm seed`
 
 The following services will then be available:
@@ -44,9 +59,16 @@ Collectivo uses [directus-sync](https://github.com/tractr/directus-sync) to appl
 Updating the database schema
 
 - Make changes to the database schema on your local system
-- Run `npx directus-sync pull && node sort-directus-config.mjs` to update the database schema in the repository
+- Update the database schema in the repository
+  ```sh
+  npx directus-sync pull && node sort-directus-config.mjs
+  ```
 - Make a database backup of the production system (see below)
-- Run `npx directus-sync push` (credentials will be taken from .env)
+- Run
+  ```sh
+  npx directus-sync push
+  ```
+  (credentials will be taken from .env)
 
 Troubleshooting
 
@@ -80,14 +102,19 @@ docker compose up -d directus-db-dev
 
 ## Local setup with Keycloak
 
-The dev setup runs without keycloak. To test keycloak integration, run both compose files:
+The dev setup runs without keycloak. To test keycloak integration:
 
-- In `collectivo/.env`, set `NUXT_PUBLIC_USE_KEYCLOAK = "true"`
-- In `.env`, set `DIRECTUS_AUTH_PROVIDERS` to `keycloak`
-- In `.env`, set `KEYCLOAK_DB_HOST = "keycloak-db"`
-- Add the following to your etc/hosts file ([here is a guide](https://www.howtogeek.com/27350/beginner-geek-how-to-edit-your-hosts-file/)): `127.0.0.1 keycloak`
-- Run `docker compose up -d keycloak-db`
-- Run `docker compose -f docker-compose.production.yml up -d keycloak`
+- In `.env`, set
+  ```
+  COMPOSE_PROFILES = "dev,keycloak"
+  KEYCLOAK_DB_HOST = "keycloak-db"
+  DIRECTUS_AUTH_PROVIDERS = "keycloak"
+  ```
+- In `collectivo/.env`, set
+  ```
+  NUXT_PUBLIC_USE_KEYCLOAK = "true"
+  ```
+- Add the following to your /etc/hosts file ([here is a guide](https://www.howtogeek.com/27350/beginner-geek-how-to-edit-your-hosts-file/)): `127.0.0.1 keycloak`
 
 Login credentials for directus admin without keycloak:
 
@@ -96,8 +123,17 @@ Login credentials for directus admin without keycloak:
 
 Login credentials for keycloak admin UI:
 
-- Username `keycloak-admin@example.com`
+- Username `admin@example.com`
 - Password `admin`
+
+For more details see the [Keycloak readme](keycloak/README.md).
+
+## Local setup with Nextcloud
+
+- In `.env`, set `COMPOSE_PROFILES = "dev,keycloak,nextcloud"`
+- Open the [Nextcloud GUI](http://localhost:8081) and create an admin user to finish the installation.
+
+For setup of the integration with keycloak see the [Nextcloud readme](nextcloud/README.md).
 
 ## Production setup
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Test users for frontend and directus (after seeding):
 - `editor@example.com` / `editor`
 - `user@example.com` / `user`
 
+Login credentials for directus admin without keycloak:
+
+- Username `directus-admin@example.com`
+- Password `admin`
+
 ## Troubleshooting
 
 - Resetting everything
@@ -114,24 +119,18 @@ The dev setup runs without keycloak. To test keycloak integration:
   ```
   NUXT_PUBLIC_USE_KEYCLOAK = "true"
   ```
-- Add the following to your /etc/hosts file ([here is a guide](https://www.howtogeek.com/27350/beginner-geek-how-to-edit-your-hosts-file/)): `127.0.0.1 keycloak`
-
-Login credentials for directus admin without keycloak:
-
-- Username `directus-admin@example.com`
-- Password `admin`
-
-Login credentials for keycloak admin UI:
-
-- Username `admin@example.com`
-- Password `admin`
+- Add the following to your /etc/hosts file ([here is a guide](https://www.howtogeek.com/27350/beginner-geek-how-to-edit-your-hosts-file/)): `127.0.0.1 keycloak` (required so your browser uses the same hostname as Docker internally, which must match the issuer embedded in Keycloak's tokens)
+- Open the Keycloak admin UI at [keycloak:8080](http://keycloak:8080).
+- Login with
+  - Username `admin@example.com`
+  - Password `admin`
 
 For more details see the [Keycloak readme](keycloak/README.md).
 
 ## Local setup with Nextcloud
 
 - In `.env`, set `COMPOSE_PROFILES = "dev,keycloak,nextcloud"`
-- Open the [Nextcloud GUI](http://localhost:8081) and create an admin user to finish the installation.
+- Open the Nextcloud GUI at [localhost:8081](http://localhost:8081) and create an admin user to finish the installation.
 
 For setup of the integration with keycloak see the [Nextcloud readme](nextcloud/README.md).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   directus-dev:
+    container_name: directus
     profiles: [dev]
     build:
       context: ./directus
@@ -34,6 +35,7 @@ services:
       FLOWS_ENV_ALLOW_LIST: "PUBLIC_URL,COLLECTIVO_API_URL,COLLECTIVO_API_TOKEN"
 
   directus-db-dev:
+    container_name: directus-db
     profiles: [dev]
     image: postgis/postgis:16-3.4-alpine
     volumes:
@@ -49,7 +51,44 @@ services:
       POSTGRES_USER: "directus"
       POSTGRES_PASSWORD: ${DIRECTUS_DB_PASSWORD}
 
+  keycloak:
+    container_name: keycloak
+    build: ./keycloak
+    profiles: [keycloak]
+    depends_on:
+      keycloak-db:
+        condition: service_healthy
+    ports:
+      - 8080:8080
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+      KC_DB_USERNAME: keycloak
+      KC_DB_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
+      KC_DB_SCHEMA: public
+      KC_DB_URL_DATABASE: "keycloak"
+      KC_DB_URL_HOST: ${KEYCLOAK_DB_HOST}
+      KC_DB_URL_PORT: 5432
+      KC_HOSTNAME: ${KEYCLOAK_DOMAIN}
+      # dev settings
+      KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
+      KC_PROXY: ${KEYCLOAK_PROXY:-none}
+    command: ${KEYCLOAK_COMMAND:-start --optimized}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - ./keycloak/themes/collectivo:/opt/keycloak/themes/collectivo
+    restart: unless-stopped
+    networks:
+      - default
+
   keycloak-db:
+    container_name: keycloak-db
+    profiles: [keycloak]
     image: postgres:14-alpine
     volumes:
       - keycloak-db-data:/var/lib/postgresql/data
@@ -63,6 +102,44 @@ services:
       POSTGRES_DB: keycloak
       POSTGRES_USER: keycloak
       POSTGRES_PASSWORD: ${KEYCLOAK_DB_PASSWORD}
+
+  nextcloud:
+    container_name: nextcloud
+    profiles: [nextcloud]
+    image: nextcloud:stable
+    restart: always
+    ports:
+      - 8081:80
+    environment:
+      MYSQL_HOST: nextcloud-db
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: nextcloudpass
+    volumes:
+      - ./nextcloud_data:/var/www/html
+    depends_on:
+      nextcloud-db:
+        condition: service_healthy
+
+  nextcloud-db:
+    container_name: nextcloud-db
+    profiles: [nextcloud]
+    image: mariadb:11 # lts
+    restart: always
+    command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: nextcloud
+      MYSQL_USER: nextcloud
+      MYSQL_PASSWORD: nextcloudpass
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 2
+      start_period: 20s
+    volumes:
+      - ./nextcloud_db_data:/var/lib/mysql
 
 volumes:
   directus-db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,14 +107,14 @@ services:
     container_name: nextcloud
     profiles: [nextcloud]
     image: nextcloud:stable
-    restart: always
+    restart: unless-stopped
     ports:
       - 8081:80
     environment:
       MYSQL_HOST: nextcloud-db
       MYSQL_DATABASE: nextcloud
       MYSQL_USER: nextcloud
-      MYSQL_PASSWORD: nextcloudpass
+      MYSQL_PASSWORD: ${NEXTCLOUD_DB_PASSWORD}
     volumes:
       - ./nextcloud_data:/var/www/html
     depends_on:
@@ -128,15 +128,15 @@ services:
     restart: always
     command: --transaction-isolation=READ-COMMITTED --binlog-format=ROW
     environment:
-      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_ROOT_PASSWORD: ${NEXTCLOUD_DB_ROOT_PASSWORD}
       MYSQL_DATABASE: nextcloud
       MYSQL_USER: nextcloud
-      MYSQL_PASSWORD: nextcloudpass
+      MYSQL_PASSWORD: ${NEXTCLOUD_DB_PASSWORD}
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
       timeout: 5s
-      retries: 2
+      retries: 10
       start_period: 20s
     volumes:
       - ./nextcloud_db_data:/var/lib/mysql

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,0 +1,27 @@
+# Keycloak
+
+[Keycloak docs](https://www.keycloak.org/docs/latest/server_admin/index.html#keycloak-features-and-concepts)
+
+## [Exporting and importing a realm](https://www.keycloak.org/server/importExport)
+
+Export collectivo realm with separate user file.
+```
+docker exec -it keycloak /opt/keycloak/bin/kc.sh export \
+  --dir /opt/keycloak/data/export \
+  --realm collectivo \
+  --users different_files
+```
+
+Copy file into repo folder `keycloak/export` and own exported files.
+```
+sudo docker cp keycloak:/opt/keycloak/data/export keycloak
+sudo chown -R my_user:users keycloak/export
+```
+
+Move to files to `keycloak/import`, delete collectivo realm from keycloak admin console, and restart the container to check whether the realm imports correctly. 
+
+With 
+```
+KEYCLOAK_COMMAND = 'start-dev --import-realm --health-enabled true'
+```
+in `.env`, the contents of `keycloak/import` are imported at startup. 

--- a/keycloak/import/collectivo-realm.json
+++ b/keycloak/import/collectivo-realm.json
@@ -1,2316 +1,1861 @@
 {
-  "id": "3bd837b9-9455-4d20-a66c-32c01127a6b9",
-  "realm": "collectivo",
-  "notBefore": 0,
-  "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": false,
-  "refreshTokenMaxReuse": 0,
-  "accessTokenLifespan": 300,
-  "accessTokenLifespanForImplicitFlow": 900,
-  "ssoSessionIdleTimeout": 1800,
-  "ssoSessionMaxLifespan": 36000,
-  "ssoSessionIdleTimeoutRememberMe": 0,
-  "ssoSessionMaxLifespanRememberMe": 0,
-  "offlineSessionIdleTimeout": 2592000,
-  "offlineSessionMaxLifespanEnabled": false,
-  "offlineSessionMaxLifespan": 5184000,
-  "clientSessionIdleTimeout": 0,
-  "clientSessionMaxLifespan": 0,
-  "clientOfflineSessionIdleTimeout": 0,
-  "clientOfflineSessionMaxLifespan": 0,
-  "accessCodeLifespan": 60,
-  "accessCodeLifespanUserAction": 300,
-  "accessCodeLifespanLogin": 1800,
-  "actionTokenGeneratedByAdminLifespan": 43200,
-  "actionTokenGeneratedByUserLifespan": 300,
-  "oauth2DeviceCodeLifespan": 600,
-  "oauth2DevicePollingInterval": 5,
-  "enabled": true,
-  "sslRequired": "external",
-  "registrationAllowed": false,
-  "registrationEmailAsUsername": true,
-  "rememberMe": false,
-  "verifyEmail": true,
-  "loginWithEmailAllowed": true,
-  "duplicateEmailsAllowed": false,
-  "resetPasswordAllowed": true,
-  "editUsernameAllowed": false,
-  "bruteForceProtected": false,
-  "permanentLockout": false,
-  "maxFailureWaitSeconds": 900,
-  "minimumQuickLoginWaitSeconds": 60,
-  "waitIncrementSeconds": 60,
-  "quickLoginCheckMilliSeconds": 1000,
-  "maxDeltaTimeSeconds": 43200,
-  "failureFactor": 30,
-  "roles": {
-    "realm": [
-      {
-        "id": "692cdfce-3e89-4b3b-9d0b-25c1c7d7957d",
-        "name": "uma_authorization",
-        "description": "${role_uma_authorization}",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "3bd837b9-9455-4d20-a66c-32c01127a6b9",
-        "attributes": {}
+  "id" : "3bd837b9-9455-4d20-a66c-32c01127a6b9",
+  "realm" : "collectivo",
+  "notBefore" : 0,
+  "defaultSignatureAlgorithm" : "RS256",
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 300,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "clientSessionIdleTimeout" : 0,
+  "clientSessionMaxLifespan" : 0,
+  "clientOfflineSessionIdleTimeout" : 0,
+  "clientOfflineSessionMaxLifespan" : 0,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "oauth2DeviceCodeLifespan" : 600,
+  "oauth2DevicePollingInterval" : 5,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : true,
+  "rememberMe" : false,
+  "verifyEmail" : true,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : true,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "692cdfce-3e89-4b3b-9d0b-25c1c7d7957d",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "3bd837b9-9455-4d20-a66c-32c01127a6b9",
+      "attributes" : { }
+    }, {
+      "id" : "69c34d3e-72a4-41bf-acb1-bff2c8a85465",
+      "name" : "default-roles-collectivo",
+      "description" : "${role_default-roles}",
+      "composite" : true,
+      "composites" : {
+        "realm" : [ "offline_access", "uma_authorization" ],
+        "client" : {
+          "account" : [ "manage-account", "view-profile" ]
+        }
       },
-      {
-        "id": "69c34d3e-72a4-41bf-acb1-bff2c8a85465",
-        "name": "default-roles-collectivo",
-        "description": "${role_default-roles}",
-        "composite": true,
-        "composites": {
-          "realm": ["offline_access", "uma_authorization"],
-          "client": {
-            "account": ["view-profile", "manage-account"]
+      "clientRole" : false,
+      "containerId" : "3bd837b9-9455-4d20-a66c-32c01127a6b9",
+      "attributes" : { }
+    }, {
+      "id" : "80cdb7bd-a256-4ff5-b18d-1ab289d338bc",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "3bd837b9-9455-4d20-a66c-32c01127a6b9",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "nextcloud" : [ ],
+      "nuxt" : [ ],
+      "realm-management" : [ {
+        "id" : "3eda56c8-b7d9-493e-b9f9-942137e971d8",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "83f3b1a6-13ee-4497-a046-0f4a0c49675b",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "40c92d72-2321-4e0d-97f2-4f468df16e9e",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "d39ecf9f-ce5d-436a-9d7c-696dc134f4d9",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
           }
         },
-        "clientRole": false,
-        "containerId": "3bd837b9-9455-4d20-a66c-32c01127a6b9",
-        "attributes": {}
-      },
-      {
-        "id": "80cdb7bd-a256-4ff5-b18d-1ab289d338bc",
-        "name": "offline_access",
-        "description": "${role_offline-access}",
-        "composite": false,
-        "clientRole": false,
-        "containerId": "3bd837b9-9455-4d20-a66c-32c01127a6b9",
-        "attributes": {}
-      }
-    ],
-    "client": {
-      "nuxt": [],
-      "realm-management": [
-        {
-          "id": "3eda56c8-b7d9-493e-b9f9-942137e971d8",
-          "name": "view-realm",
-          "description": "${role_view-realm}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "cb5a7e9c-23ea-43e2-a40f-8653047120ba",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "30b70ffb-365e-49ef-83e3-164106d5c97d",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "dab10a10-a58c-4551-a033-e10dca19d75a",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "145baf44-6973-470c-806b-19ca775e7496",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "c7cd700d-8880-4def-bdea-18b044846a9c",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "457133ad-b423-4a70-838c-06f69078a2cd",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
         },
-        {
-          "id": "83f3b1a6-13ee-4497-a046-0f4a0c49675b",
-          "name": "manage-events",
-          "description": "${role_manage-events}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "f20ee611-4e2a-49c1-8bb9-a2e01c5ef6f6",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "658a2f75-7255-449a-9ca3-5ae00b6c2445",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "864ae7f0-d5e2-46dc-b873-b0ede0d2408e",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "view-realm", "manage-events", "create-client", "view-clients", "view-authorization", "manage-authorization", "view-identity-providers", "query-clients", "manage-identity-providers", "view-users", "impersonation", "query-groups", "query-users", "manage-clients", "manage-users", "manage-realm", "query-realms", "view-events" ]
+          }
         },
-        {
-          "id": "40c92d72-2321-4e0d-97f2-4f468df16e9e",
-          "name": "create-client",
-          "description": "${role_create-client}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "e2ece71b-2d18-40b3-9e73-f665b9013055",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "a0253f7b-e3b0-4b0d-a6aa-40032757a67c",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "f0970110-c208-41c9-8671-b0cad5b4b945",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "3c0fae44-7502-40da-b49e-32f4095bccd9",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "a6569e9b-3c06-4caa-9981-b6d807b238da",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      }, {
+        "id" : "0bf22256-f243-4696-95dc-e7aa84c09520",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "account-console" : [ ],
+      "broker" : [ {
+        "id" : "869e1352-2a67-410f-b2f1-c8cc63185cb1",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "61919de5-b806-4558-9295-0e20def5634a",
+        "attributes" : { }
+      } ],
+      "directus" : [ ],
+      "account" : [ {
+        "id" : "9056a678-411e-4451-b53e-fdbd22511241",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
         },
-        {
-          "id": "d39ecf9f-ce5d-436a-9d7c-696dc134f4d9",
-          "name": "view-clients",
-          "description": "${role_view-clients}",
-          "composite": true,
-          "composites": {
-            "client": {
-              "realm-management": ["query-clients"]
-            }
-          },
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      }, {
+        "id" : "86f9d5b8-d0aa-442f-98a6-a24f77e128a2",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      }, {
+        "id" : "cb75fc4a-c660-4cec-a4f7-44f43972200a",
+        "name" : "delete-account",
+        "description" : "${role_delete-account}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      }, {
+        "id" : "060fa486-dae8-4cc6-b973-a73c20d1fa9f",
+        "name" : "view-consent",
+        "description" : "${role_view-consent}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      }, {
+        "id" : "1fa45054-dddc-4367-a1ce-dfd6e0214f91",
+        "name" : "view-groups",
+        "description" : "${role_view-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      }, {
+        "id" : "b7ed1f00-0140-4754-bb95-2e8b008d2d4d",
+        "name" : "view-applications",
+        "description" : "${role_view-applications}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      }, {
+        "id" : "0a7bc343-075d-407a-bc40-fd08fa0bebf9",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      }, {
+        "id" : "e90feb6b-d426-4955-a663-d54e3978e350",
+        "name" : "manage-consent",
+        "description" : "${role_manage-consent}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "view-consent" ]
+          }
         },
-        {
-          "id": "cb5a7e9c-23ea-43e2-a40f-8653047120ba",
-          "name": "view-authorization",
-          "description": "${role_view-authorization}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "30b70ffb-365e-49ef-83e3-164106d5c97d",
-          "name": "manage-authorization",
-          "description": "${role_manage-authorization}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "dab10a10-a58c-4551-a033-e10dca19d75a",
-          "name": "view-identity-providers",
-          "description": "${role_view-identity-providers}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "145baf44-6973-470c-806b-19ca775e7496",
-          "name": "query-clients",
-          "description": "${role_query-clients}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "c7cd700d-8880-4def-bdea-18b044846a9c",
-          "name": "manage-identity-providers",
-          "description": "${role_manage-identity-providers}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "457133ad-b423-4a70-838c-06f69078a2cd",
-          "name": "view-users",
-          "description": "${role_view-users}",
-          "composite": true,
-          "composites": {
-            "client": {
-              "realm-management": ["query-groups", "query-users"]
-            }
-          },
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "f20ee611-4e2a-49c1-8bb9-a2e01c5ef6f6",
-          "name": "impersonation",
-          "description": "${role_impersonation}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "658a2f75-7255-449a-9ca3-5ae00b6c2445",
-          "name": "query-groups",
-          "description": "${role_query-groups}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "864ae7f0-d5e2-46dc-b873-b0ede0d2408e",
-          "name": "realm-admin",
-          "description": "${role_realm-admin}",
-          "composite": true,
-          "composites": {
-            "client": {
-              "realm-management": [
-                "view-realm",
-                "manage-events",
-                "create-client",
-                "view-clients",
-                "view-authorization",
-                "manage-authorization",
-                "view-identity-providers",
-                "query-clients",
-                "manage-identity-providers",
-                "view-users",
-                "impersonation",
-                "query-groups",
-                "query-users",
-                "manage-clients",
-                "manage-users",
-                "view-events",
-                "manage-realm",
-                "query-realms"
-              ]
-            }
-          },
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "e2ece71b-2d18-40b3-9e73-f665b9013055",
-          "name": "query-users",
-          "description": "${role_query-users}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "a0253f7b-e3b0-4b0d-a6aa-40032757a67c",
-          "name": "manage-clients",
-          "description": "${role_manage-clients}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "f0970110-c208-41c9-8671-b0cad5b4b945",
-          "name": "manage-users",
-          "description": "${role_manage-users}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "3c0fae44-7502-40da-b49e-32f4095bccd9",
-          "name": "manage-realm",
-          "description": "${role_manage-realm}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "a6569e9b-3c06-4caa-9981-b6d807b238da",
-          "name": "query-realms",
-          "description": "${role_query-realms}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        },
-        {
-          "id": "0bf22256-f243-4696-95dc-e7aa84c09520",
-          "name": "view-events",
-          "description": "${role_view-events}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-          "attributes": {}
-        }
-      ],
-      "security-admin-console": [],
-      "admin-cli": [],
-      "account-console": [],
-      "broker": [
-        {
-          "id": "869e1352-2a67-410f-b2f1-c8cc63185cb1",
-          "name": "read-token",
-          "description": "${role_read-token}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "61919de5-b806-4558-9295-0e20def5634a",
-          "attributes": {}
-        }
-      ],
-      "directus": [],
-      "account": [
-        {
-          "id": "9056a678-411e-4451-b53e-fdbd22511241",
-          "name": "manage-account",
-          "description": "${role_manage-account}",
-          "composite": true,
-          "composites": {
-            "client": {
-              "account": ["manage-account-links"]
-            }
-          },
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        },
-        {
-          "id": "86f9d5b8-d0aa-442f-98a6-a24f77e128a2",
-          "name": "view-profile",
-          "description": "${role_view-profile}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        },
-        {
-          "id": "cb75fc4a-c660-4cec-a4f7-44f43972200a",
-          "name": "delete-account",
-          "description": "${role_delete-account}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        },
-        {
-          "id": "060fa486-dae8-4cc6-b973-a73c20d1fa9f",
-          "name": "view-consent",
-          "description": "${role_view-consent}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        },
-        {
-          "id": "1fa45054-dddc-4367-a1ce-dfd6e0214f91",
-          "name": "view-groups",
-          "description": "${role_view-groups}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        },
-        {
-          "id": "b7ed1f00-0140-4754-bb95-2e8b008d2d4d",
-          "name": "view-applications",
-          "description": "${role_view-applications}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        },
-        {
-          "id": "0a7bc343-075d-407a-bc40-fd08fa0bebf9",
-          "name": "manage-account-links",
-          "description": "${role_manage-account-links}",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        },
-        {
-          "id": "e90feb6b-d426-4955-a663-d54e3978e350",
-          "name": "manage-consent",
-          "description": "${role_manage-consent}",
-          "composite": true,
-          "composites": {
-            "client": {
-              "account": ["view-consent"]
-            }
-          },
-          "clientRole": true,
-          "containerId": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-          "attributes": {}
-        }
-      ]
+        "clientRole" : true,
+        "containerId" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+        "attributes" : { }
+      } ]
     }
   },
-  "groups": [],
-  "defaultRole": {
-    "id": "69c34d3e-72a4-41bf-acb1-bff2c8a85465",
-    "name": "default-roles-collectivo",
-    "description": "${role_default-roles}",
-    "composite": true,
-    "clientRole": false,
-    "containerId": "3bd837b9-9455-4d20-a66c-32c01127a6b9"
+  "groups" : [ ],
+  "defaultRole" : {
+    "id" : "69c34d3e-72a4-41bf-acb1-bff2c8a85465",
+    "name" : "default-roles-collectivo",
+    "description" : "${role_default-roles}",
+    "composite" : true,
+    "clientRole" : false,
+    "containerId" : "3bd837b9-9455-4d20-a66c-32c01127a6b9"
   },
-  "requiredCredentials": ["password"],
-  "otpPolicyType": "totp",
-  "otpPolicyAlgorithm": "HmacSHA1",
-  "otpPolicyInitialCounter": 0,
-  "otpPolicyDigits": 6,
-  "otpPolicyLookAheadWindow": 1,
-  "otpPolicyPeriod": 30,
-  "otpPolicyCodeReusable": false,
-  "otpSupportedApplications": [
-    "totpAppFreeOTPName",
-    "totpAppGoogleName",
-    "totpAppMicrosoftAuthenticatorName"
-  ],
-  "webAuthnPolicyRpEntityName": "keycloak",
-  "webAuthnPolicySignatureAlgorithms": ["ES256"],
-  "webAuthnPolicyRpId": "",
-  "webAuthnPolicyAttestationConveyancePreference": "not specified",
-  "webAuthnPolicyAuthenticatorAttachment": "not specified",
-  "webAuthnPolicyRequireResidentKey": "not specified",
-  "webAuthnPolicyUserVerificationRequirement": "not specified",
-  "webAuthnPolicyCreateTimeout": 0,
-  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
-  "webAuthnPolicyAcceptableAaguids": [],
-  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
-  "webAuthnPolicyPasswordlessSignatureAlgorithms": ["ES256"],
-  "webAuthnPolicyPasswordlessRpId": "",
-  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
-  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
-  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
-  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
-  "webAuthnPolicyPasswordlessCreateTimeout": 0,
-  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
-  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
-  "users": [
-    {
-      "id": "beaf498c-a994-44ff-b4cb-cbf0710ca0d0",
-      "createdTimestamp": 1703688693500,
-      "username": "service-account-admin-cli",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": false,
-      "serviceAccountClientId": "admin-cli",
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": [
-        "offline_access",
-        "uma_authorization",
-        "default-roles-collectivo"
-      ],
-      "clientRoles": {
-        "realm-management": [
-          "view-realm",
-          "manage-events",
-          "manage-authorization",
-          "query-clients",
-          "view-users",
-          "realm-admin",
-          "view-events",
-          "manage-realm",
-          "create-client",
-          "view-clients",
-          "view-authorization",
-          "view-identity-providers",
-          "manage-identity-providers",
-          "impersonation",
-          "query-groups",
-          "query-users",
-          "manage-users",
-          "manage-clients",
-          "query-realms"
-        ],
-        "broker": ["read-token"],
-        "account": [
-          "view-profile",
-          "manage-account",
-          "delete-account",
-          "manage-consent",
-          "view-applications",
-          "view-groups",
-          "view-consent",
-          "manage-account-links"
-        ]
-      },
-      "notBefore": 0,
-      "groups": []
-    },
-    {
-      "id": "49bfa679-4393-4f51-b372-c12cc40ed085",
-      "createdTimestamp": 1697096551946,
-      "username": "admin@example.com",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": true,
-      "firstName": "Admin",
-      "lastName": "Example",
-      "email": "admin@example.com",
-      "credentials": [
-        {
-          "id": "c082252b-8bb2-4882-93d6-911c6cf5320e",
-          "type": "password",
-          "userLabel": "My password",
-          "createdDate": 1697096569039,
-          "secretData": "{\"value\":\"zkatZx0E/bGR33MCsgo+ZjyFbaR9on8p1yxuDtwsMLM=\",\"salt\":\"OODcXFn3qUvbSYfrqiDe3g==\",\"additionalParameters\":{}}",
-          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
-        }
-      ],
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": ["default-roles-collectivo"],
-      "notBefore": 0,
-      "groups": []
-    },
-    {
-      "id": "7c18a9d7-e508-41ef-8c15-191562fc6291",
-      "createdTimestamp": 1700059405993,
-      "username": "editor@example.com",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": true,
-      "firstName": "Editor",
-      "lastName": "Example",
-      "email": "editor@example.com",
-      "credentials": [
-        {
-          "id": "7dc97ef7-08e5-40fb-a341-7536e36f2f00",
-          "type": "password",
-          "userLabel": "My password",
-          "createdDate": 1700059417104,
-          "secretData": "{\"value\":\"HT2OBSqKBz+GbrEypScJHlEZAVmIcjLy5hEyDhj81yk=\",\"salt\":\"1LNj+oXZOId69zHb/hIxxA==\",\"additionalParameters\":{}}",
-          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
-        }
-      ],
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": ["default-roles-collectivo"],
-      "notBefore": 0,
-      "groups": []
-    },
-    {
-      "id": "1f0042d1-9a1b-4b41-b39e-4d135e60856c",
-      "createdTimestamp": 1697096484471,
-      "username": "user@example.com",
-      "enabled": true,
-      "totp": false,
-      "emailVerified": true,
-      "firstName": "User",
-      "lastName": "Example",
-      "email": "user@example.com",
-      "credentials": [
-        {
-          "id": "5b597453-edf7-42f6-b425-9cef425d41c2",
-          "type": "password",
-          "userLabel": "My password",
-          "createdDate": 1697096532500,
-          "secretData": "{\"value\":\"fgGniieuvQiWTebHCsbK1teYLljLdAkxqC342JoypVk=\",\"salt\":\"CsW3KFF8XZ9eW5KV0+W/QQ==\",\"additionalParameters\":{}}",
-          "credentialData": "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
-        }
-      ],
-      "disableableCredentialTypes": [],
-      "requiredActions": [],
-      "realmRoles": ["default-roles-collectivo"],
-      "notBefore": 0,
-      "groups": []
-    }
-  ],
-  "scopeMappings": [
-    {
-      "clientScope": "offline_access",
-      "roles": ["offline_access"]
-    }
-  ],
-  "clientScopeMappings": {
-    "account": [
-      {
-        "client": "account-console",
-        "roles": ["manage-account", "view-groups"]
-      }
-    ]
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpPolicyCodeReusable" : false,
+  "otpSupportedApplications" : [ "totpAppFreeOTPName", "totpAppGoogleName", "totpAppMicrosoftAuthenticatorName" ],
+  "localizationTexts" : { },
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "webAuthnPolicyExtraOrigins" : [ ],
+  "webAuthnPolicyPasswordlessRpEntityName" : "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyPasswordlessRpId" : "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey" : "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout" : 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids" : [ ],
+  "webAuthnPolicyPasswordlessExtraOrigins" : [ ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clientScopeMappings" : {
+    "account" : [ {
+      "client" : "account-console",
+      "roles" : [ "manage-account", "view-groups" ]
+    } ]
   },
-  "clients": [
-    {
-      "id": "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
-      "clientId": "account",
-      "name": "${client_account}",
-      "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/collectivo/account/",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["/realms/collectivo/account/*"],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "post.logout.redirect.uris": "+"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": 0,
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
+  "clients" : [ {
+    "id" : "0f456b8b-95d9-46be-8bd1-30416c28c5dd",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/collectivo/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/collectivo/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
     },
-    {
-      "id": "b4c6e686-cc5e-4395-82a9-270ba1441817",
-      "clientId": "account-console",
-      "name": "${client_account-console}",
-      "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/collectivo/account/",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["/realms/collectivo/account/*"],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "post.logout.redirect.uris": "+",
-        "pkce.code.challenge.method": "S256"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": 0,
-      "protocolMappers": [
-        {
-          "id": "289bae12-2a4e-4342-b35d-dede22e4e13b",
-          "name": "audience resolve",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-resolve-mapper",
-          "consentRequired": false,
-          "config": {}
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "b4c6e686-cc5e-4395-82a9-270ba1441817",
+    "clientId" : "account-console",
+    "name" : "${client_account-console}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/collectivo/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/realms/collectivo/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
     },
-    {
-      "id": "aba3f24c-1962-47d6-ae2c-0e6ab212b382",
-      "clientId": "admin-cli",
-      "name": "${client_admin-cli}",
-      "rootUrl": "http://localhost:3000/",
-      "adminUrl": "http://localhost:3000/",
-      "baseUrl": "http://localhost:3000/",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": [],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": false,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": true,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "post.logout.redirect.uris": "+"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": 0,
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "289bae12-2a4e-4342-b35d-dede22e4e13b",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "aba3f24c-1962-47d6-ae2c-0e6ab212b382",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "rootUrl" : "http://localhost:3000/",
+    "adminUrl" : "http://localhost:3000/",
+    "baseUrl" : "http://localhost:3000/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "**********",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : true,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
     },
-    {
-      "id": "61919de5-b806-4558-9295-0e20def5634a",
-      "clientId": "broker",
-      "name": "${client_broker}",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": [],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": true,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "post.logout.redirect.uris": "+"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": 0,
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "61919de5-b806-4558-9295-0e20def5634a",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
     },
-    {
-      "id": "1b5b17a1-f1e8-4bf2-bf5e-b24b9bcc6feb",
-      "clientId": "directus",
-      "name": "",
-      "description": "",
-      "rootUrl": "http://localhost:8055/",
-      "adminUrl": "http://localhost:8055/",
-      "baseUrl": "http://localhost:8055/",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "**********",
-      "redirectUris": ["*"],
-      "webOrigins": ["+"],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": false,
-      "frontchannelLogout": true,
-      "protocol": "openid-connect",
-      "attributes": {
-        "oidc.ciba.grant.enabled": "false",
-        "client.secret.creation.time": "1692797248",
-        "backchannel.logout.session.required": "true",
-        "post.logout.redirect.uris": "http://localhost:8055/",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "display.on.consent.screen": "false",
-        "backchannel.logout.revoke.offline.tokens": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "1b5b17a1-f1e8-4bf2-bf5e-b24b9bcc6feb",
+    "clientId" : "directus",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "http://localhost:8055/",
+    "adminUrl" : "http://localhost:8055/",
+    "baseUrl" : "http://localhost:8055/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "**********",
+    "redirectUris" : [ "*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1692797248",
+      "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "http://localhost:8055/",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "display.on.consent.screen" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false"
     },
-    {
-      "id": "af4c4ba2-fbed-498f-b942-0efd3354ba77",
-      "clientId": "nuxt",
-      "name": "",
-      "description": "",
-      "rootUrl": "http://localhost:3000/",
-      "adminUrl": "http://localhost:3000/",
-      "baseUrl": "http://localhost:3000/",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["http://localhost:3000/*"],
-      "webOrigins": ["*"],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
-      "frontchannelLogout": true,
-      "protocol": "openid-connect",
-      "attributes": {
-        "post.logout.redirect.uris": "http://localhost:3000/*",
-        "oauth2.device.authorization.grant.enabled": "false",
-        "backchannel.logout.revoke.offline.tokens": "false",
-        "use.refresh.tokens": "true",
-        "oidc.ciba.grant.enabled": "false",
-        "backchannel.logout.session.required": "true",
-        "client_credentials.use_refresh_token": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "require.pushed.authorization.requests": "false",
-        "acr.loa.map": "{}",
-        "display.on.consent.screen": "false",
-        "token.response.type.bearer.lower-case": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "ed3c3fbf-bdab-4cdf-b2d7-860ce6d72d4a",
+    "clientId" : "nextcloud",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "http://localhost:8081/*",
+    "adminUrl" : "http://localhost:8081/*",
+    "baseUrl" : "http://localhost:8081/*",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://localhost:8081/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "post.logout.redirect.uris" : "http://localhost:8081/*",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "backchannel.logout.revoke.offline.tokens" : "false"
     },
-    {
-      "id": "ab59206d-8e24-4cf4-9eab-09c559bedd80",
-      "clientId": "realm-management",
-      "name": "${client_realm-management}",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": [],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": true,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "post.logout.redirect.uris": "+"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": 0,
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "af4c4ba2-fbed-498f-b942-0efd3354ba77",
+    "clientId" : "nuxt",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "http://localhost:3000/",
+    "adminUrl" : "http://localhost:3000/",
+    "baseUrl" : "http://localhost:3000/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "http://localhost:3000/*" ],
+    "webOrigins" : [ "*" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "http://localhost:3000/*",
+      "oauth2.device.authorization.grant.enabled" : "false",
+      "backchannel.logout.revoke.offline.tokens" : "false",
+      "use.refresh.tokens" : "true",
+      "oidc.ciba.grant.enabled" : "false",
+      "backchannel.logout.session.required" : "true",
+      "client_credentials.use_refresh_token" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "require.pushed.authorization.requests" : "false",
+      "acr.loa.map" : "{}",
+      "display.on.consent.screen" : "false",
+      "token.response.type.bearer.lower-case" : "false"
     },
-    {
-      "id": "03514d1c-9463-4127-b96e-aba0ebbd3354",
-      "clientId": "security-admin-console",
-      "name": "${client_security-admin-console}",
-      "rootUrl": "${authAdminUrl}",
-      "baseUrl": "/admin/collectivo/console/",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["/admin/collectivo/console/*"],
-      "webOrigins": ["+"],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "post.logout.redirect.uris": "+",
-        "pkce.code.challenge.method": "S256"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": false,
-      "nodeReRegistrationTimeout": 0,
-      "protocolMappers": [
-        {
-          "id": "062c1a4c-1a0c-4814-a6c2-b848cad6b250",
-          "name": "locale",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "locale",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "locale",
-            "jsonType.label": "String"
-          }
-        }
-      ],
-      "defaultClientScopes": [
-        "web-origins",
-        "acr",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access",
-        "microprofile-jwt"
-      ]
-    }
-  ],
-  "clientScopes": [
-    {
-      "id": "16e6eb5c-dc51-4e60-b137-9d3ea709e259",
-      "name": "profile",
-      "description": "OpenID Connect built-in scope: profile",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${profileScopeConsentText}"
-      },
-      "protocolMappers": [
-        {
-          "id": "0f03fe43-3e39-4cbf-a6f3-527071e35807",
-          "name": "locale",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "locale",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "locale",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "4d3c6986-b2db-45b8-8380-ae3a99452701",
-          "name": "given name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "firstName",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "given_name",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "c0ab1353-10e6-40e2-8fac-733967512eb8",
-          "name": "picture",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "picture",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "picture",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "a175a94a-e6cc-485a-923a-59735e4878d8",
-          "name": "updated at",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "updatedAt",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "updated_at",
-            "jsonType.label": "long"
-          }
-        },
-        {
-          "id": "f8ec04db-7878-43fe-9793-7bd3138c48e0",
-          "name": "middle name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "middleName",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "middle_name",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "0e52a2a1-36e6-4c3d-ac96-ff063617f314",
-          "name": "birthdate",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "birthdate",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "birthdate",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "869b63a6-295d-479a-8dc1-01e44764c8cc",
-          "name": "full name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-full-name-mapper",
-          "consentRequired": false,
-          "config": {
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "userinfo.token.claim": "true"
-          }
-        },
-        {
-          "id": "c93b86dd-da63-4d5f-9341-ca2cd85ca49f",
-          "name": "zoneinfo",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "zoneinfo",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "zoneinfo",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "e9c9b2de-41bf-40ef-ad73-0505d7e4b550",
-          "name": "nickname",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "nickname",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "nickname",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "1a654bba-6410-4139-9470-4ac077556bb5",
-          "name": "profile",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "profile",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "profile",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "ec54ecbc-381b-46a7-8864-630f074203b2",
-          "name": "gender",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "gender",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "gender",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "2991e184-9fec-4f9a-adb1-8cf7c3d9cc6e",
-          "name": "family name",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "lastName",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "family_name",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "8feeba0d-d252-4baf-bfd2-0b2daede14ea",
-          "name": "username",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "username",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "preferred_username",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "0f48fb7d-ab2a-455c-8c57-badf0e29d144",
-          "name": "website",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "website",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "website",
-            "jsonType.label": "String"
-          }
-        }
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "ab59206d-8e24-4cf4-9eab-09c559bedd80",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+"
     },
-    {
-      "id": "10a28f9b-d7ce-4427-88cc-dc090bc458e3",
-      "name": "address",
-      "description": "OpenID Connect built-in scope: address",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${addressScopeConsentText}"
-      },
-      "protocolMappers": [
-        {
-          "id": "e75b07be-e51a-4c90-8776-7f79c1fee1f8",
-          "name": "address",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-address-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.attribute.formatted": "formatted",
-            "user.attribute.country": "country",
-            "user.attribute.postal_code": "postal_code",
-            "userinfo.token.claim": "true",
-            "user.attribute.street": "street",
-            "id.token.claim": "true",
-            "user.attribute.region": "region",
-            "access.token.claim": "true",
-            "user.attribute.locality": "locality"
-          }
-        }
-      ]
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "03514d1c-9463-4127-b96e-aba0ebbd3354",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/collectivo/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "redirectUris" : [ "/admin/collectivo/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "post.logout.redirect.uris" : "+",
+      "pkce.code.challenge.method" : "S256"
     },
-    {
-      "id": "db35916a-1a5b-4bf5-bd8d-9290711bfa57",
-      "name": "offline_access",
-      "description": "OpenID Connect built-in scope: offline_access",
-      "protocol": "openid-connect",
-      "attributes": {
-        "consent.screen.text": "${offlineAccessScopeConsentText}",
-        "display.on.consent.screen": "true"
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "062c1a4c-1a0c-4814-a6c2-b848cad6b250",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
       }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "acr", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "16e6eb5c-dc51-4e60-b137-9d3ea709e259",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
     },
-    {
-      "id": "ea9b57e1-3519-4561-8115-bbbb08805ff0",
-      "name": "email",
-      "description": "OpenID Connect built-in scope: email",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${emailScopeConsentText}"
-      },
-      "protocolMappers": [
-        {
-          "id": "542ad354-114a-4cee-83d9-93957b2cbb16",
-          "name": "email",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "email",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "email",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "97b8fb7e-7018-4879-b3bd-fbb932c32072",
-          "name": "email verified",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-property-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "emailVerified",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "email_verified",
-            "jsonType.label": "boolean"
-          }
-        }
-      ]
+    "protocolMappers" : [ {
+      "id" : "0f03fe43-3e39-4cbf-a6f3-527071e35807",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4d3c6986-b2db-45b8-8380-ae3a99452701",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "c0ab1353-10e6-40e2-8fac-733967512eb8",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "a175a94a-e6cc-485a-923a-59735e4878d8",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "long"
+      }
+    }, {
+      "id" : "f8ec04db-7878-43fe-9793-7bd3138c48e0",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0e52a2a1-36e6-4c3d-ac96-ff063617f314",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "869b63a6-295d-479a-8dc1-01e44764c8cc",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "c93b86dd-da63-4d5f-9341-ca2cd85ca49f",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e9c9b2de-41bf-40ef-ad73-0505d7e4b550",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "1a654bba-6410-4139-9470-4ac077556bb5",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ec54ecbc-381b-46a7-8864-630f074203b2",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "2991e184-9fec-4f9a-adb1-8cf7c3d9cc6e",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "8feeba0d-d252-4baf-bfd2-0b2daede14ea",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0f48fb7d-ab2a-455c-8c57-badf0e29d144",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "10a28f9b-d7ce-4427-88cc-dc090bc458e3",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
     },
-    {
-      "id": "d257aa74-c5dc-46d9-9dce-5075a2ee5b89",
-      "name": "web-origins",
-      "description": "OpenID Connect scope for add allowed web origins to the access token",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "false",
-        "display.on.consent.screen": "false",
-        "consent.screen.text": ""
-      },
-      "protocolMappers": [
-        {
-          "id": "a493efbe-9799-4a6e-92c6-e62df7e3bd5f",
-          "name": "allowed web origins",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-allowed-origins-mapper",
-          "consentRequired": false,
-          "config": {}
-        }
-      ]
-    },
-    {
-      "id": "de3c845b-9b42-4836-a2ba-c65851b5cfe3",
-      "name": "microprofile-jwt",
-      "description": "Microprofile - JWT built-in scope",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "false"
-      },
-      "protocolMappers": [
-        {
-          "id": "057b9039-135a-4e12-87d9-9c9191e731d9",
-          "name": "groups",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-realm-role-mapper",
-          "consentRequired": false,
-          "config": {
-            "multivalued": "true",
-            "userinfo.token.claim": "true",
-            "user.attribute": "foo",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "groups",
-            "jsonType.label": "String"
-          }
-        },
-        {
-          "id": "69933184-34bc-40bf-a9f5-44be5b697a73",
-          "name": "upn",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "username",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "upn",
-            "jsonType.label": "String"
-          }
-        }
-      ]
-    },
-    {
-      "id": "f0b166e4-c31a-4599-9e8d-ba7a917cad99",
-      "name": "role_list",
-      "description": "SAML role list",
-      "protocol": "saml",
-      "attributes": {
-        "consent.screen.text": "${samlRoleListScopeConsentText}",
-        "display.on.consent.screen": "true"
-      },
-      "protocolMappers": [
-        {
-          "id": "1932b4f0-c346-4209-aba8-6c4bdb49e03e",
-          "name": "role list",
-          "protocol": "saml",
-          "protocolMapper": "saml-role-list-mapper",
-          "consentRequired": false,
-          "config": {
-            "single": "false",
-            "attribute.nameformat": "Basic",
-            "attribute.name": "Role"
-          }
-        }
-      ]
-    },
-    {
-      "id": "e6a458be-f95f-4649-8f31-95f68fe115af",
-      "name": "phone",
-      "description": "OpenID Connect built-in scope: phone",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "true",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${phoneScopeConsentText}"
-      },
-      "protocolMappers": [
-        {
-          "id": "6fb8f15f-0297-422e-aa97-94560e14742a",
-          "name": "phone number verified",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "phoneNumberVerified",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "phone_number_verified",
-            "jsonType.label": "boolean"
-          }
-        },
-        {
-          "id": "b82aa642-e2a6-45e5-a38d-34f4c1d93a62",
-          "name": "phone number",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-attribute-mapper",
-          "consentRequired": false,
-          "config": {
-            "userinfo.token.claim": "true",
-            "user.attribute": "phoneNumber",
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "claim.name": "phone_number",
-            "jsonType.label": "String"
-          }
-        }
-      ]
-    },
-    {
-      "id": "24f7a361-f46e-4fbd-8aa5-03c95c1283a6",
-      "name": "roles",
-      "description": "OpenID Connect scope for add user roles to the access token",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "false",
-        "display.on.consent.screen": "true",
-        "consent.screen.text": "${rolesScopeConsentText}"
-      },
-      "protocolMappers": [
-        {
-          "id": "2f43f707-6668-4a16-adff-fea73bdd9e0b",
-          "name": "audience resolve",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-audience-resolve-mapper",
-          "consentRequired": false,
-          "config": {}
-        },
-        {
-          "id": "96f767a0-fccd-44e3-9719-356ab12fcf36",
-          "name": "client roles",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-client-role-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.attribute": "foo",
-            "access.token.claim": "true",
-            "claim.name": "resource_access.${client_id}.roles",
-            "jsonType.label": "String",
-            "multivalued": "true"
-          }
-        },
-        {
-          "id": "1c89cf47-7149-4cc5-b795-3e385760e4f9",
-          "name": "realm roles",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-usermodel-realm-role-mapper",
-          "consentRequired": false,
-          "config": {
-            "user.attribute": "foo",
-            "access.token.claim": "true",
-            "claim.name": "realm_access.roles",
-            "jsonType.label": "String",
-            "multivalued": "true"
-          }
-        }
-      ]
-    },
-    {
-      "id": "0f9fe5c9-2e05-466f-8dc5-abd324483d1b",
-      "name": "acr",
-      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
-      "protocol": "openid-connect",
-      "attributes": {
-        "include.in.token.scope": "false",
-        "display.on.consent.screen": "false"
-      },
-      "protocolMappers": [
-        {
-          "id": "6d489b4a-b117-4580-aace-8ca3b5d7fb83",
-          "name": "acr loa level",
-          "protocol": "openid-connect",
-          "protocolMapper": "oidc-acr-mapper",
-          "consentRequired": false,
-          "config": {
-            "id.token.claim": "true",
-            "access.token.claim": "true",
-            "userinfo.token.claim": "true"
-          }
-        }
-      ]
+    "protocolMappers" : [ {
+      "id" : "e75b07be-e51a-4c90-8776-7f79c1fee1f8",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "db35916a-1a5b-4bf5-bd8d-9290711bfa57",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
     }
-  ],
-  "defaultDefaultClientScopes": [
-    "role_list",
-    "profile",
-    "email",
-    "roles",
-    "web-origins",
-    "acr"
-  ],
-  "defaultOptionalClientScopes": [
-    "offline_access",
-    "address",
-    "phone",
-    "microprofile-jwt"
-  ],
-  "browserSecurityHeaders": {
-    "contentSecurityPolicyReportOnly": "",
-    "xContentTypeOptions": "nosniff",
-    "referrerPolicy": "no-referrer",
-    "xRobotsTag": "none",
-    "xFrameOptions": "SAMEORIGIN",
-    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
-    "xXSSProtection": "1; mode=block",
-    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  }, {
+    "id" : "ea9b57e1-3519-4561-8115-bbbb08805ff0",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "542ad354-114a-4cee-83d9-93957b2cbb16",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "97b8fb7e-7018-4879-b3bd-fbb932c32072",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "d257aa74-c5dc-46d9-9dce-5075a2ee5b89",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "a493efbe-9799-4a6e-92c6-e62df7e3bd5f",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "de3c845b-9b42-4836-a2ba-c65851b5cfe3",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "057b9039-135a-4e12-87d9-9c9191e731d9",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "69933184-34bc-40bf-a9f5-44be5b697a73",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "f0b166e4-c31a-4599-9e8d-ba7a917cad99",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "1932b4f0-c346-4209-aba8-6c4bdb49e03e",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "e6a458be-f95f-4649-8f31-95f68fe115af",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "6fb8f15f-0297-422e-aa97-94560e14742a",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    }, {
+      "id" : "b82aa642-e2a6-45e5-a38d-34f4c1d93a62",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "24f7a361-f46e-4fbd-8aa5-03c95c1283a6",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "2f43f707-6668-4a16-adff-fea73bdd9e0b",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    }, {
+      "id" : "96f767a0-fccd-44e3-9719-356ab12fcf36",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "1c89cf47-7149-4cc5-b795-3e385760e4f9",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    } ]
+  }, {
+    "id" : "0f9fe5c9-2e05-466f-8dc5-abd324483d1b",
+    "name" : "acr",
+    "description" : "OpenID Connect scope for add acr (authentication context class reference) to the token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "6d489b4a-b117-4580-aace-8ca3b5d7fb83",
+      "name" : "acr loa level",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-acr-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "role_list", "profile", "email", "roles", "web-origins", "acr" ],
+  "defaultOptionalClientScopes" : [ "offline_access", "address", "phone", "microprofile-jwt" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "referrerPolicy" : "no-referrer",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
   },
-  "smtpServer": {},
-  "eventsEnabled": false,
-  "eventsListeners": ["jboss-logging"],
-  "enabledEventTypes": [],
-  "adminEventsEnabled": false,
-  "adminEventsDetailsEnabled": false,
-  "identityProviders": [],
-  "identityProviderMappers": [],
-  "components": {
-    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
-      {
-        "id": "cb03a374-9e40-459c-aff9-2f07646682df",
-        "name": "Allowed Client Scopes",
-        "providerId": "allowed-client-templates",
-        "subType": "authenticated",
-        "subComponents": {},
-        "config": {
-          "allow-default-scopes": ["true"]
-        }
-      },
-      {
-        "id": "b0fbca6a-da68-4008-8ca2-6d378e25b621",
-        "name": "Full Scope Disabled",
-        "providerId": "scope",
-        "subType": "anonymous",
-        "subComponents": {},
-        "config": {}
-      },
-      {
-        "id": "ca7afd75-5dff-44d0-8480-a84ffd0c2299",
-        "name": "Allowed Protocol Mapper Types",
-        "providerId": "allowed-protocol-mappers",
-        "subType": "anonymous",
-        "subComponents": {},
-        "config": {
-          "allowed-protocol-mapper-types": [
-            "oidc-full-name-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "saml-user-attribute-mapper",
-            "oidc-sha256-pairwise-sub-mapper",
-            "saml-role-list-mapper",
-            "oidc-usermodel-property-mapper",
-            "saml-user-property-mapper",
-            "oidc-address-mapper"
-          ]
-        }
-      },
-      {
-        "id": "5a33d71a-a874-4aa6-b137-019c557248dd",
-        "name": "Allowed Protocol Mapper Types",
-        "providerId": "allowed-protocol-mappers",
-        "subType": "authenticated",
-        "subComponents": {},
-        "config": {
-          "allowed-protocol-mapper-types": [
-            "oidc-sha256-pairwise-sub-mapper",
-            "oidc-address-mapper",
-            "saml-user-attribute-mapper",
-            "oidc-usermodel-attribute-mapper",
-            "saml-role-list-mapper",
-            "oidc-full-name-mapper",
-            "oidc-usermodel-property-mapper",
-            "saml-user-property-mapper"
-          ]
-        }
-      },
-      {
-        "id": "e10b4a05-e434-4f75-a033-35af9ae3ff6c",
-        "name": "Max Clients Limit",
-        "providerId": "max-clients",
-        "subType": "anonymous",
-        "subComponents": {},
-        "config": {
-          "max-clients": ["200"]
-        }
-      },
-      {
-        "id": "fc3ea96f-8eb2-4026-a7b4-8f6231283d35",
-        "name": "Allowed Client Scopes",
-        "providerId": "allowed-client-templates",
-        "subType": "anonymous",
-        "subComponents": {},
-        "config": {
-          "allow-default-scopes": ["true"]
-        }
-      },
-      {
-        "id": "d4015884-36ef-48b9-b442-386dd124ff25",
-        "name": "Trusted Hosts",
-        "providerId": "trusted-hosts",
-        "subType": "anonymous",
-        "subComponents": {},
-        "config": {
-          "host-sending-registration-request-must-match": ["true"],
-          "client-uris-must-match": ["true"]
-        }
-      },
-      {
-        "id": "4293e8bd-0f08-4c39-9688-da596c1d6bbd",
-        "name": "Consent Required",
-        "providerId": "consent-required",
-        "subType": "anonymous",
-        "subComponents": {},
-        "config": {}
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "identityProviders" : [ ],
+  "identityProviderMappers" : [ ],
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "cb03a374-9e40-459c-aff9-2f07646682df",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
       }
-    ],
-    "org.keycloak.keys.KeyProvider": [
-      {
-        "id": "b3aeabe5-fb64-4452-b361-b600295f2f4d",
-        "name": "rsa-generated",
-        "providerId": "rsa-generated",
-        "subComponents": {},
-        "config": {
-          "privateKey": [
-            "MIIEpAIBAAKCAQEAo8LJBLBoJREhljTwFo3X+09iTlU3EKOWI8um4pPGRL5iPrYadhVEqj8VfnKgSrFuNLKJ8zuv/B8PP6XOqptlMJqmc61fOWxGCK9qcmKxP77lG62yCxs4uVk2p4bm2FYJHXAgCUoahQgG0SqNXwYUo6y/KCJKzgSzmwM/vWFeiRcbni4drVent9iY6CU1EYusSikm5j/0vtTSX6+A+vm0n7tXkTaIf3N8i6YVlP1mjEOXzDYYN6t5uKo+UyeG/gzFpxYsKMj0YPFCfQs6A5VXT0skGQbe9Qg2yO41W1XoMfNfc9ex6hvsz/B9CC8ja9nDPwtu0IOj6osLcp1C5SaatQIDAQABAoIBAC0g9j2lEaY5YNygjRNiFoWqnEhDApBCzJLjwgNJvwddwfxPOd6VwNz70oQMubCr0deS5iJSLg7YTl73ZgstFMc+ryVMv2O3O1uUX8zS9s6+4CtvBBQ8dbbaZ43mRsKSfyOOLT3yHnnPuvU0eU4ZAmISroE0ZhH9SLOswwmBBkjX1Pa/hzwZpiBsqiJRFGFrQ/Cl1nujNNrX3dmKVKyKNo4XR0oZHn6EgxYQmsZowItRGeWkSpF8uQM7ayCpMmRW0BL7f0SOmu8PBO7WnkCq7G1YJt8GD2nkH31rtqe7/JcrAO0q597dreq1tcV0+vQsPZ2acI+KuLVIeGc7OkE+yhcCgYEA1Gocp2DW19sOJ28fDWxxcVRTZTSKUPRXNLkYHv+AHqBGhmARzwQAixwxcNyRFuR94eQiWAPTF7NWY1uI/Fs8Wn7PiC+ZPyOtMxICqtF7AaCEemT+Aj5+A2ImwMOJB0W2LUGPWlh57FheC6O7CXGBknMFMxwwflj/bI3fXMlQfLMCgYEAxVz0dD3gbGJcXqYwNUJ3ccDcUx5egj8Cen/FjauTDmno5s2Ia443TyZG042SrOFutDdhmgiUjrpjNVmwSZErxJSgG19H034df5c1MZ5Anm/h3jJCngxEZlZTnqSBfIsXnGAySS9WpyBTYWh/Lh/5qdCNZlIONlR1H3uCAu7hjvcCgYEAi/V299pY9VWC1/zh6whfHxs+79pUoM6+fyDOge47zvIwRe4bDdpHOWHUOdc7Smg3gZW+A1xRxLYH3+O6OP0soTwZJlSmlvG893+QflkUwZewcq0EqRngEf6kJjMwoLgQN3WRLShK/a2kGetCHBDMHWDoNisG0Nl3Q2GfoRWMkP0CgYBlsc0ALHX8Qv6HgqhqeRIk2hRs+8QE5sS3LCk2I4dFsQriClvV19TmAroR/evrCsnJMJQpE2zA0oeWEN3GOnhL9a0+DW1sK5q1iMtPAtUXDl1a6Zjr6TRBaw/xOaDC9MS4vdSLY0oKGZz9HyQRN0ak2qJRa8yI8CHdk/1c14v/5wKBgQDSv1yM6oq1mnS2ZReUGfTm/DE+O96nAbnI3oFqYiBrBYXWrcLdDI+Cdn5+yienudw0dzkzcPUE+i8ExsM7+eHh05uFf/bXYrBqDkRpiLsG/oZMGgQUtkqK83BGGtmZykBvKjrtgDXU7bhx/QcHWbCkR3K1s6QnVJzHKk62MLFsYg=="
-          ],
-          "certificate": [
-            "MIICozCCAYsCBgGLGNiVwjANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApjb2xsZWN0aXZvMB4XDTIzMTAxMDA5MDcwOVoXDTMzMTAxMDA5MDg0OVowFTETMBEGA1UEAwwKY29sbGVjdGl2bzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKPCyQSwaCURIZY08BaN1/tPYk5VNxCjliPLpuKTxkS+Yj62GnYVRKo/FX5yoEqxbjSyifM7r/wfDz+lzqqbZTCapnOtXzlsRgivanJisT++5RutsgsbOLlZNqeG5thWCR1wIAlKGoUIBtEqjV8GFKOsvygiSs4Es5sDP71hXokXG54uHa1Xp7fYmOglNRGLrEopJuY/9L7U0l+vgPr5tJ+7V5E2iH9zfIumFZT9ZoxDl8w2GDerebiqPlMnhv4MxacWLCjI9GDxQn0LOgOVV09LJBkG3vUINsjuNVtV6DHzX3PXseob7M/wfQgvI2vZwz8LbtCDo+qLC3KdQuUmmrUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEACLO0YRDrUf74845/r7h3+oNpOuGkOK0Efqb5+CO0X36AF20dVhdYt3Djg4REgKVmje3oX3O89i+fzJnlvI8e0bJOQYD8Mzw7coeYvRiGfzdyq+5W/BLt5EptlZgZUa5Br3Uv5zLODGqCMF4olTs4DnmE/Ex5e/CHa9nPQbsDHOH0VLSExZx8l0zaiMjy3802TLgjPKe7IL3+gA41SRiiXNoELguLuk2O5p1tC0GJptEKN1NvrSmIYCQruUfCFn8QaqYX5igBxhUm75Q4APSS1GSP/D8U2NbTPY3GiEutmUDmuEsaOZzg1crH8Hqd5KqZ/JBC0f5lQUzT7vE4TvfEhA=="
-          ],
-          "priority": ["100"]
-        }
-      },
-      {
-        "id": "307f22eb-7d3e-4495-a793-a98dd0f91a92",
-        "name": "hmac-generated",
-        "providerId": "hmac-generated",
-        "subComponents": {},
-        "config": {
-          "kid": ["3d8e0580-9da5-4c42-8ac7-36ebc80a5fa7"],
-          "secret": [
-            "N5hvVEMxcimyKyyj5EdXQqKDqDlbfp_hUTae_W2LC5OOY5aBUoO3QPpdP18p9wZBo-xgF92xrOQ-c5mlmMjM2w"
-          ],
-          "priority": ["100"],
-          "algorithm": ["HS256"]
-        }
-      },
-      {
-        "id": "8dbae105-ad75-4cb4-853e-028a5730ac55",
-        "name": "rsa-enc-generated",
-        "providerId": "rsa-enc-generated",
-        "subComponents": {},
-        "config": {
-          "privateKey": [
-            "MIIEowIBAAKCAQEA1T4cCk0NmMxAPtnMMD89L0w5uzQ9iDRkriQDUsUlspsvlrYW0pgDq6aq8kMOQan7BhxG3zF9it9Lm5KwSvA5R8/v1Cen71mpwmB0UHa+yQX7PGRxnS0stGX8BP0h6rKUpFQB6eMWW0woAxt/ViTNBm0nFr1S6u+GYxGtuVLozc10WEdOQwrOMnKpInI1OCTqnT4RytjO6um3LQZqc10GM00aA3624xivIfVwFOhTquT2hCSg6DeNpIpZpZi6Q2Ok9AQfNoRGOn1k5Ab2crE2XynOu4a0xW/Zd99eri1CrWQ3rgXmhs/TsK98fB/DPQustE7F42WfktWmtn/mw+4Y7wIDAQABAoIBAA38gWVRkXs8plgY+/IMK8yu4Lh9IC4PVa0wUoF6ydKxqAjoD44nh1IaX+r85/H5nqvTbfiUq+nQZIqjL+nyYKdrpYzSPwsNY/uKTQa8Cx5vRH+9DNCk1mJMsB95pOBabzJqCigXi29YiuVNR+hUCJiLzz0IFOiw5i0YSz81B2z8FqKegagwvRARpj2Qa5YJH+WAgQ8guaANOnBNW8bZNr4DEwwuE1KmTyNA6ybfWYRs9Sj0OztszPvqFDgQdBUAhgdBALMSSt86RhjK7tb3SYsEL+UTtMh2R+hhIY368vayPrh6t4Y6t1mHSP2F1VAGsS5eev3iCEsp2VIE9/A1ToECgYEA8i+8VUTT0dx6MLzJf0nzNZnWNKEmDjSpFEXz3ANIIcvLYD8I+lxlbZcsLZttt+4DWQ45x8Gkek0ENAF9LeCnoyCNcQO9KTTldY6qjmQaGX5dCSgGSYZdxhSddpYGPKTb5gNPXl7642SuhPAn3NoIko/xFedonGMJ6sLtvAs7QG8CgYEA4WfAtIWmjFK2ULhm7CiTcSRgLXdAqKor4btmhnHtq13HwnKIpSq9CStBazkZY+ry+G/oojOGokM91qll1dmpJ+zVG9X9lJQhm7adE3bVvCviyGtLqTQ6SJdWKNMgkKuVXdzF9OCtoJErbdXybj3ZXvwYwpLmo4dVjARZNFRF74ECgYASfAY509j+6X8B/Ua7yl8ftjAdMDeBWg+Vlok4P5/fxHgvTmBXC3pKVQFwMa68HRRwVZ+fWW4+T2aEuaBeQglJcBCbkZd8b6cbw9nMqGM9kuFy83UXY4QAvE4QYP703fhSo+oI3+LyPBr91n6UYqfI1+ekrlbTqNN28Y3HjmvlTQKBgF4cdq4ou1ANXMe5JmflzSHJQUraZqnFW0sFdpodyVDqd/Qs4/aqMIE6iTbegUZhm461EtleUBFBp/kPg1BVb7YWwSe9IgI+EwYzqcOtszG81RQ/EDkWcFtMrJGhDRC6Q0QMYK6MfJH06sASOwViV3a8JQ5gTWHrqIEsc55QrV6BAoGBAMU+0GZm2uyNbHcX9pOu6dNO9tTfLxR0h0K0wHJTzjWF1c2PXmyhEYiaRuA7Z30KPdx5NYY5AJyPsCdBbl4t7vsxL5YoNLt2h6hbwqF4DpPKQk3+op78y/WU9yUoPELZLD0eIY6ZBb8NNTUNNGugsqxNxv2/cJUiOYCRmBeRyFD0"
-          ],
-          "certificate": [
-            "MIICozCCAYsCBgGLGNiWgzANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApjb2xsZWN0aXZvMB4XDTIzMTAxMDA5MDcwOVoXDTMzMTAxMDA5MDg0OVowFTETMBEGA1UEAwwKY29sbGVjdGl2bzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANU+HApNDZjMQD7ZzDA/PS9MObs0PYg0ZK4kA1LFJbKbL5a2FtKYA6umqvJDDkGp+wYcRt8xfYrfS5uSsErwOUfP79Qnp+9ZqcJgdFB2vskF+zxkcZ0tLLRl/AT9IeqylKRUAenjFltMKAMbf1YkzQZtJxa9UurvhmMRrblS6M3NdFhHTkMKzjJyqSJyNTgk6p0+EcrYzurpty0GanNdBjNNGgN+tuMYryH1cBToU6rk9oQkoOg3jaSKWaWYukNjpPQEHzaERjp9ZOQG9nKxNl8pzruGtMVv2XffXq4tQq1kN64F5obP07CvfHwfwz0LrLROxeNln5LVprZ/5sPuGO8CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAILmtnIfc3PoP1Qy5tyfeQ+pC6S8oof6/V8malugARD+bHgIqAD/7ccTrYoB9OBCWGJoz57fdeSJitaBIrpog9sd6bhldJK/WIgfHguxrHD3fUFZlQSPtVyV/qjiswsaFKpe7ExwjReMw3W/SjFxEnJ5oyue0h8VCMwz3iv6YcAq0Tdzot3jIqsMx9YzlUICU70pNZgY9BlEbT8e9OAudLPCrPv84+vRI8zasV4aLs/qCApavdjxAuGXuJE7kSruWq5/urXv/mkJUa2/nAZhd/ovFeP8rkbuErQtYWICCK6Mu8YZR5m2Dn5OJXYyw34c0m2gLAXlyFKRnw3+37huV/g=="
-          ],
-          "priority": ["100"],
-          "algorithm": ["RSA-OAEP"]
-        }
-      },
-      {
-        "id": "8da8d188-e5aa-4d4a-8a5b-747290d2a46a",
-        "name": "aes-generated",
-        "providerId": "aes-generated",
-        "subComponents": {},
-        "config": {
-          "kid": ["bcd549e4-2883-4f17-8b0f-d5276dc1db35"],
-          "secret": ["kafusPz7A1tATc5NuLPU_A"],
-          "priority": ["100"]
-        }
+    }, {
+      "id" : "b0fbca6a-da68-4008-8ca2-6d378e25b621",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "ca7afd75-5dff-44d0-8480-a84ffd0c2299",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-full-name-mapper", "saml-user-property-mapper", "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "saml-role-list-mapper" ]
       }
-    ]
+    }, {
+      "id" : "5a33d71a-a874-4aa6-b137-019c557248dd",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-usermodel-property-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper", "oidc-address-mapper" ]
+      }
+    }, {
+      "id" : "e10b4a05-e434-4f75-a033-35af9ae3ff6c",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "fc3ea96f-8eb2-4026-a7b4-8f6231283d35",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "d4015884-36ef-48b9-b442-386dd124ff25",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "4293e8bd-0f08-4c39-9688-da596c1d6bbd",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "b3aeabe5-fb64-4452-b361-b600295f2f4d",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEpAIBAAKCAQEAo8LJBLBoJREhljTwFo3X+09iTlU3EKOWI8um4pPGRL5iPrYadhVEqj8VfnKgSrFuNLKJ8zuv/B8PP6XOqptlMJqmc61fOWxGCK9qcmKxP77lG62yCxs4uVk2p4bm2FYJHXAgCUoahQgG0SqNXwYUo6y/KCJKzgSzmwM/vWFeiRcbni4drVent9iY6CU1EYusSikm5j/0vtTSX6+A+vm0n7tXkTaIf3N8i6YVlP1mjEOXzDYYN6t5uKo+UyeG/gzFpxYsKMj0YPFCfQs6A5VXT0skGQbe9Qg2yO41W1XoMfNfc9ex6hvsz/B9CC8ja9nDPwtu0IOj6osLcp1C5SaatQIDAQABAoIBAC0g9j2lEaY5YNygjRNiFoWqnEhDApBCzJLjwgNJvwddwfxPOd6VwNz70oQMubCr0deS5iJSLg7YTl73ZgstFMc+ryVMv2O3O1uUX8zS9s6+4CtvBBQ8dbbaZ43mRsKSfyOOLT3yHnnPuvU0eU4ZAmISroE0ZhH9SLOswwmBBkjX1Pa/hzwZpiBsqiJRFGFrQ/Cl1nujNNrX3dmKVKyKNo4XR0oZHn6EgxYQmsZowItRGeWkSpF8uQM7ayCpMmRW0BL7f0SOmu8PBO7WnkCq7G1YJt8GD2nkH31rtqe7/JcrAO0q597dreq1tcV0+vQsPZ2acI+KuLVIeGc7OkE+yhcCgYEA1Gocp2DW19sOJ28fDWxxcVRTZTSKUPRXNLkYHv+AHqBGhmARzwQAixwxcNyRFuR94eQiWAPTF7NWY1uI/Fs8Wn7PiC+ZPyOtMxICqtF7AaCEemT+Aj5+A2ImwMOJB0W2LUGPWlh57FheC6O7CXGBknMFMxwwflj/bI3fXMlQfLMCgYEAxVz0dD3gbGJcXqYwNUJ3ccDcUx5egj8Cen/FjauTDmno5s2Ia443TyZG042SrOFutDdhmgiUjrpjNVmwSZErxJSgG19H034df5c1MZ5Anm/h3jJCngxEZlZTnqSBfIsXnGAySS9WpyBTYWh/Lh/5qdCNZlIONlR1H3uCAu7hjvcCgYEAi/V299pY9VWC1/zh6whfHxs+79pUoM6+fyDOge47zvIwRe4bDdpHOWHUOdc7Smg3gZW+A1xRxLYH3+O6OP0soTwZJlSmlvG893+QflkUwZewcq0EqRngEf6kJjMwoLgQN3WRLShK/a2kGetCHBDMHWDoNisG0Nl3Q2GfoRWMkP0CgYBlsc0ALHX8Qv6HgqhqeRIk2hRs+8QE5sS3LCk2I4dFsQriClvV19TmAroR/evrCsnJMJQpE2zA0oeWEN3GOnhL9a0+DW1sK5q1iMtPAtUXDl1a6Zjr6TRBaw/xOaDC9MS4vdSLY0oKGZz9HyQRN0ak2qJRa8yI8CHdk/1c14v/5wKBgQDSv1yM6oq1mnS2ZReUGfTm/DE+O96nAbnI3oFqYiBrBYXWrcLdDI+Cdn5+yienudw0dzkzcPUE+i8ExsM7+eHh05uFf/bXYrBqDkRpiLsG/oZMGgQUtkqK83BGGtmZykBvKjrtgDXU7bhx/QcHWbCkR3K1s6QnVJzHKk62MLFsYg==" ],
+        "certificate" : [ "MIICozCCAYsCBgGLGNiVwjANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApjb2xsZWN0aXZvMB4XDTIzMTAxMDA5MDcwOVoXDTMzMTAxMDA5MDg0OVowFTETMBEGA1UEAwwKY29sbGVjdGl2bzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKPCyQSwaCURIZY08BaN1/tPYk5VNxCjliPLpuKTxkS+Yj62GnYVRKo/FX5yoEqxbjSyifM7r/wfDz+lzqqbZTCapnOtXzlsRgivanJisT++5RutsgsbOLlZNqeG5thWCR1wIAlKGoUIBtEqjV8GFKOsvygiSs4Es5sDP71hXokXG54uHa1Xp7fYmOglNRGLrEopJuY/9L7U0l+vgPr5tJ+7V5E2iH9zfIumFZT9ZoxDl8w2GDerebiqPlMnhv4MxacWLCjI9GDxQn0LOgOVV09LJBkG3vUINsjuNVtV6DHzX3PXseob7M/wfQgvI2vZwz8LbtCDo+qLC3KdQuUmmrUCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEACLO0YRDrUf74845/r7h3+oNpOuGkOK0Efqb5+CO0X36AF20dVhdYt3Djg4REgKVmje3oX3O89i+fzJnlvI8e0bJOQYD8Mzw7coeYvRiGfzdyq+5W/BLt5EptlZgZUa5Br3Uv5zLODGqCMF4olTs4DnmE/Ex5e/CHa9nPQbsDHOH0VLSExZx8l0zaiMjy3802TLgjPKe7IL3+gA41SRiiXNoELguLuk2O5p1tC0GJptEKN1NvrSmIYCQruUfCFn8QaqYX5igBxhUm75Q4APSS1GSP/D8U2NbTPY3GiEutmUDmuEsaOZzg1crH8Hqd5KqZ/JBC0f5lQUzT7vE4TvfEhA==" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "307f22eb-7d3e-4495-a793-a98dd0f91a92",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "3d8e0580-9da5-4c42-8ac7-36ebc80a5fa7" ],
+        "secret" : [ "N5hvVEMxcimyKyyj5EdXQqKDqDlbfp_hUTae_W2LC5OOY5aBUoO3QPpdP18p9wZBo-xgF92xrOQ-c5mlmMjM2w" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "8dbae105-ad75-4cb4-853e-028a5730ac55",
+      "name" : "rsa-enc-generated",
+      "providerId" : "rsa-enc-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEA1T4cCk0NmMxAPtnMMD89L0w5uzQ9iDRkriQDUsUlspsvlrYW0pgDq6aq8kMOQan7BhxG3zF9it9Lm5KwSvA5R8/v1Cen71mpwmB0UHa+yQX7PGRxnS0stGX8BP0h6rKUpFQB6eMWW0woAxt/ViTNBm0nFr1S6u+GYxGtuVLozc10WEdOQwrOMnKpInI1OCTqnT4RytjO6um3LQZqc10GM00aA3624xivIfVwFOhTquT2hCSg6DeNpIpZpZi6Q2Ok9AQfNoRGOn1k5Ab2crE2XynOu4a0xW/Zd99eri1CrWQ3rgXmhs/TsK98fB/DPQustE7F42WfktWmtn/mw+4Y7wIDAQABAoIBAA38gWVRkXs8plgY+/IMK8yu4Lh9IC4PVa0wUoF6ydKxqAjoD44nh1IaX+r85/H5nqvTbfiUq+nQZIqjL+nyYKdrpYzSPwsNY/uKTQa8Cx5vRH+9DNCk1mJMsB95pOBabzJqCigXi29YiuVNR+hUCJiLzz0IFOiw5i0YSz81B2z8FqKegagwvRARpj2Qa5YJH+WAgQ8guaANOnBNW8bZNr4DEwwuE1KmTyNA6ybfWYRs9Sj0OztszPvqFDgQdBUAhgdBALMSSt86RhjK7tb3SYsEL+UTtMh2R+hhIY368vayPrh6t4Y6t1mHSP2F1VAGsS5eev3iCEsp2VIE9/A1ToECgYEA8i+8VUTT0dx6MLzJf0nzNZnWNKEmDjSpFEXz3ANIIcvLYD8I+lxlbZcsLZttt+4DWQ45x8Gkek0ENAF9LeCnoyCNcQO9KTTldY6qjmQaGX5dCSgGSYZdxhSddpYGPKTb5gNPXl7642SuhPAn3NoIko/xFedonGMJ6sLtvAs7QG8CgYEA4WfAtIWmjFK2ULhm7CiTcSRgLXdAqKor4btmhnHtq13HwnKIpSq9CStBazkZY+ry+G/oojOGokM91qll1dmpJ+zVG9X9lJQhm7adE3bVvCviyGtLqTQ6SJdWKNMgkKuVXdzF9OCtoJErbdXybj3ZXvwYwpLmo4dVjARZNFRF74ECgYASfAY509j+6X8B/Ua7yl8ftjAdMDeBWg+Vlok4P5/fxHgvTmBXC3pKVQFwMa68HRRwVZ+fWW4+T2aEuaBeQglJcBCbkZd8b6cbw9nMqGM9kuFy83UXY4QAvE4QYP703fhSo+oI3+LyPBr91n6UYqfI1+ekrlbTqNN28Y3HjmvlTQKBgF4cdq4ou1ANXMe5JmflzSHJQUraZqnFW0sFdpodyVDqd/Qs4/aqMIE6iTbegUZhm461EtleUBFBp/kPg1BVb7YWwSe9IgI+EwYzqcOtszG81RQ/EDkWcFtMrJGhDRC6Q0QMYK6MfJH06sASOwViV3a8JQ5gTWHrqIEsc55QrV6BAoGBAMU+0GZm2uyNbHcX9pOu6dNO9tTfLxR0h0K0wHJTzjWF1c2PXmyhEYiaRuA7Z30KPdx5NYY5AJyPsCdBbl4t7vsxL5YoNLt2h6hbwqF4DpPKQk3+op78y/WU9yUoPELZLD0eIY6ZBb8NNTUNNGugsqxNxv2/cJUiOYCRmBeRyFD0" ],
+        "certificate" : [ "MIICozCCAYsCBgGLGNiWgzANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDDApjb2xsZWN0aXZvMB4XDTIzMTAxMDA5MDcwOVoXDTMzMTAxMDA5MDg0OVowFTETMBEGA1UEAwwKY29sbGVjdGl2bzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANU+HApNDZjMQD7ZzDA/PS9MObs0PYg0ZK4kA1LFJbKbL5a2FtKYA6umqvJDDkGp+wYcRt8xfYrfS5uSsErwOUfP79Qnp+9ZqcJgdFB2vskF+zxkcZ0tLLRl/AT9IeqylKRUAenjFltMKAMbf1YkzQZtJxa9UurvhmMRrblS6M3NdFhHTkMKzjJyqSJyNTgk6p0+EcrYzurpty0GanNdBjNNGgN+tuMYryH1cBToU6rk9oQkoOg3jaSKWaWYukNjpPQEHzaERjp9ZOQG9nKxNl8pzruGtMVv2XffXq4tQq1kN64F5obP07CvfHwfwz0LrLROxeNln5LVprZ/5sPuGO8CAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAILmtnIfc3PoP1Qy5tyfeQ+pC6S8oof6/V8malugARD+bHgIqAD/7ccTrYoB9OBCWGJoz57fdeSJitaBIrpog9sd6bhldJK/WIgfHguxrHD3fUFZlQSPtVyV/qjiswsaFKpe7ExwjReMw3W/SjFxEnJ5oyue0h8VCMwz3iv6YcAq0Tdzot3jIqsMx9YzlUICU70pNZgY9BlEbT8e9OAudLPCrPv84+vRI8zasV4aLs/qCApavdjxAuGXuJE7kSruWq5/urXv/mkJUa2/nAZhd/ovFeP8rkbuErQtYWICCK6Mu8YZR5m2Dn5OJXYyw34c0m2gLAXlyFKRnw3+37huV/g==" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "RSA-OAEP" ]
+      }
+    }, {
+      "id" : "8da8d188-e5aa-4d4a-8a5b-747290d2a46a",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "bcd549e4-2883-4f17-8b0f-d5276dc1db35" ],
+        "secret" : [ "kafusPz7A1tATc5NuLPU_A" ],
+        "priority" : [ "100" ]
+      }
+    } ]
   },
-  "internationalizationEnabled": false,
-  "supportedLocales": [],
-  "authenticationFlows": [
-    {
-      "id": "9175f214-10a4-4945-86e4-f8654e6a4dc6",
-      "alias": "Account verification options",
-      "description": "Method with which to verity the existing account",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "idp-email-verification",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "ALTERNATIVE",
-          "priority": 20,
-          "autheticatorFlow": true,
-          "flowAlias": "Verify Existing Account by Re-authentication",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "db409260-0e90-4504-b0fa-31f24d1e174d",
-      "alias": "Browser - Conditional OTP",
-      "description": "Flow to determine if the OTP is required for the authentication",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "conditional-user-configured",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "auth-otp-form",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "06f5b206-d859-42f3-b223-ae2a8e62533f",
-      "alias": "Direct Grant - Conditional OTP",
-      "description": "Flow to determine if the OTP is required for the authentication",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "conditional-user-configured",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "direct-grant-validate-otp",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "91d4093f-6348-44f3-9f80-cc3a8e72336e",
-      "alias": "First broker login - Conditional OTP",
-      "description": "Flow to determine if the OTP is required for the authentication",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "conditional-user-configured",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "auth-otp-form",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "29fed87e-1248-45c4-841c-4821ce8f2421",
-      "alias": "Handle Existing Account",
-      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "idp-confirm-link",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": true,
-          "flowAlias": "Account verification options",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "ad038a4b-4745-4d13-9351-1874be75117b",
-      "alias": "Reset - Conditional OTP",
-      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "conditional-user-configured",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "reset-otp",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "106fd6a1-675e-4f5f-92ad-ec19d8769e5b",
-      "alias": "User creation or linking",
-      "description": "Flow for the existing/non-existing user alternatives",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticatorConfig": "create unique user config",
-          "authenticator": "idp-create-user-if-unique",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "ALTERNATIVE",
-          "priority": 20,
-          "autheticatorFlow": true,
-          "flowAlias": "Handle Existing Account",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "7403d18d-b496-46e6-899d-d5da0660a01b",
-      "alias": "Verify Existing Account by Re-authentication",
-      "description": "Reauthentication of existing account",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "idp-username-password-form",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "CONDITIONAL",
-          "priority": 20,
-          "autheticatorFlow": true,
-          "flowAlias": "First broker login - Conditional OTP",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "698bc897-21b9-49a6-9a9f-7e49c1805aea",
-      "alias": "browser",
-      "description": "browser based authentication",
-      "providerId": "basic-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "auth-cookie",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "auth-spnego",
-          "authenticatorFlow": false,
-          "requirement": "DISABLED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "identity-provider-redirector",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 25,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "ALTERNATIVE",
-          "priority": 30,
-          "autheticatorFlow": true,
-          "flowAlias": "forms",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "e2061f77-6096-409d-951b-25e05d4184f7",
-      "alias": "clients",
-      "description": "Base authentication for clients",
-      "providerId": "client-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "client-secret",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "client-jwt",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "client-secret-jwt",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 30,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "client-x509",
-          "authenticatorFlow": false,
-          "requirement": "ALTERNATIVE",
-          "priority": 40,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "1e65167e-c4bf-43c5-973b-13a58179790d",
-      "alias": "direct grant",
-      "description": "OpenID Connect Resource Owner Grant",
-      "providerId": "basic-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "direct-grant-validate-username",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "direct-grant-validate-password",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "CONDITIONAL",
-          "priority": 30,
-          "autheticatorFlow": true,
-          "flowAlias": "Direct Grant - Conditional OTP",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "14a9cb94-e192-4dab-8a5f-a85682384d25",
-      "alias": "docker auth",
-      "description": "Used by Docker clients to authenticate against the IDP",
-      "providerId": "basic-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "docker-http-basic-authenticator",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "ca595bd0-c9ca-4a5b-90a4-0e148cd638ef",
-      "alias": "first broker login",
-      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
-      "providerId": "basic-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticatorConfig": "review profile config",
-          "authenticator": "idp-review-profile",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": true,
-          "flowAlias": "User creation or linking",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "eaa3f404-95c1-4d69-a13c-af22ef581244",
-      "alias": "forms",
-      "description": "Username, password, otp and other auth forms.",
-      "providerId": "basic-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "auth-username-password-form",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "CONDITIONAL",
-          "priority": 20,
-          "autheticatorFlow": true,
-          "flowAlias": "Browser - Conditional OTP",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "a7539688-9f65-4bdc-9724-b071a077ab72",
-      "alias": "registration",
-      "description": "registration flow",
-      "providerId": "basic-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "registration-page-form",
-          "authenticatorFlow": true,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": true,
-          "flowAlias": "registration form",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "3ae5b0f9-4260-4388-a940-19d51c10cf63",
-      "alias": "registration form",
-      "description": "registration form",
-      "providerId": "form-flow",
-      "topLevel": false,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "registration-user-creation",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "registration-profile-action",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 40,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "registration-password-action",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 50,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "registration-recaptcha-action",
-          "authenticatorFlow": false,
-          "requirement": "DISABLED",
-          "priority": 60,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "03f4d3ea-a42a-46fc-b4a4-d2e8d3c93f6f",
-      "alias": "reset credentials",
-      "description": "Reset credentials for a user if they forgot their password or something",
-      "providerId": "basic-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "reset-credentials-choose-user",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "reset-credential-email",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 20,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticator": "reset-password",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 30,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        },
-        {
-          "authenticatorFlow": true,
-          "requirement": "CONDITIONAL",
-          "priority": 40,
-          "autheticatorFlow": true,
-          "flowAlias": "Reset - Conditional OTP",
-          "userSetupAllowed": false
-        }
-      ]
-    },
-    {
-      "id": "5ab5e065-5951-431b-8d36-1c435a780ecf",
-      "alias": "saml ecp",
-      "description": "SAML ECP Profile Authentication Flow",
-      "providerId": "basic-flow",
-      "topLevel": true,
-      "builtIn": true,
-      "authenticationExecutions": [
-        {
-          "authenticator": "http-basic-authenticator",
-          "authenticatorFlow": false,
-          "requirement": "REQUIRED",
-          "priority": 10,
-          "autheticatorFlow": false,
-          "userSetupAllowed": false
-        }
-      ]
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "9175f214-10a4-4945-86e4-f8654e6a4dc6",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "db409260-0e90-4504-b0fa-31f24d1e174d",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "06f5b206-d859-42f3-b223-ae2a8e62533f",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "91d4093f-6348-44f3-9f80-cc3a8e72336e",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "29fed87e-1248-45c4-841c-4821ce8f2421",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ad038a4b-4745-4d13-9351-1874be75117b",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "106fd6a1-675e-4f5f-92ad-ec19d8769e5b",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "7403d18d-b496-46e6-899d-d5da0660a01b",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "698bc897-21b9-49a6-9a9f-7e49c1805aea",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "e2061f77-6096-409d-951b-25e05d4184f7",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "client-x509",
+      "authenticatorFlow" : false,
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "1e65167e-c4bf-43c5-973b-13a58179790d",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "14a9cb94-e192-4dab-8a5f-a85682384d25",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "ca595bd0-c9ca-4a5b-90a4-0e148cd638ef",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "eaa3f404-95c1-4d69-a13c-af22ef581244",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "a7539688-9f65-4bdc-9724-b071a077ab72",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "authenticatorFlow" : true,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : true,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "3ae5b0f9-4260-4388-a940-19d51c10cf63",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "authenticatorFlow" : false,
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "03f4d3ea-a42a-46fc-b4a4-d2e8d3c93f6f",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticator" : "reset-password",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    }, {
+      "authenticatorFlow" : true,
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "autheticatorFlow" : true,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false
+    } ]
+  }, {
+    "id" : "5ab5e065-5951-431b-8d36-1c435a780ecf",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "authenticatorFlow" : false,
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "autheticatorFlow" : false,
+      "userSetupAllowed" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "8f7aafe3-2e02-4235-a589-cbd602bded84",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
     }
-  ],
-  "authenticatorConfig": [
-    {
-      "id": "8f7aafe3-2e02-4235-a589-cbd602bded84",
-      "alias": "create unique user config",
-      "config": {
-        "require.password.update.after.registration": "false"
-      }
-    },
-    {
-      "id": "3fb546f0-ea0d-4526-b553-5b5a12dd6431",
-      "alias": "review profile config",
-      "config": {
-        "update.profile.on.first.login": "missing"
-      }
+  }, {
+    "id" : "3fb546f0-ea0d-4526-b553-5b5a12dd6431",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
     }
-  ],
-  "requiredActions": [
-    {
-      "alias": "CONFIGURE_TOTP",
-      "name": "Configure OTP",
-      "providerId": "CONFIGURE_TOTP",
-      "enabled": true,
-      "defaultAction": false,
-      "priority": 10,
-      "config": {}
-    },
-    {
-      "alias": "TERMS_AND_CONDITIONS",
-      "name": "Terms and Conditions",
-      "providerId": "TERMS_AND_CONDITIONS",
-      "enabled": false,
-      "defaultAction": false,
-      "priority": 20,
-      "config": {}
-    },
-    {
-      "alias": "UPDATE_PASSWORD",
-      "name": "Update Password",
-      "providerId": "UPDATE_PASSWORD",
-      "enabled": true,
-      "defaultAction": false,
-      "priority": 30,
-      "config": {}
-    },
-    {
-      "alias": "UPDATE_PROFILE",
-      "name": "Update Profile",
-      "providerId": "UPDATE_PROFILE",
-      "enabled": true,
-      "defaultAction": false,
-      "priority": 40,
-      "config": {}
-    },
-    {
-      "alias": "VERIFY_EMAIL",
-      "name": "Verify Email",
-      "providerId": "VERIFY_EMAIL",
-      "enabled": true,
-      "defaultAction": false,
-      "priority": 50,
-      "config": {}
-    },
-    {
-      "alias": "delete_account",
-      "name": "Delete Account",
-      "providerId": "delete_account",
-      "enabled": false,
-      "defaultAction": false,
-      "priority": 60,
-      "config": {}
-    },
-    {
-      "alias": "webauthn-register",
-      "name": "Webauthn Register",
-      "providerId": "webauthn-register",
-      "enabled": true,
-      "defaultAction": false,
-      "priority": 70,
-      "config": {}
-    },
-    {
-      "alias": "webauthn-register-passwordless",
-      "name": "Webauthn Register Passwordless",
-      "providerId": "webauthn-register-passwordless",
-      "enabled": true,
-      "defaultAction": false,
-      "priority": 80,
-      "config": {}
-    },
-    {
-      "alias": "update_user_locale",
-      "name": "Update User Locale",
-      "providerId": "update_user_locale",
-      "enabled": true,
-      "defaultAction": false,
-      "priority": 1000,
-      "config": {}
-    }
-  ],
-  "browserFlow": "browser",
-  "registrationFlow": "registration",
-  "directGrantFlow": "direct grant",
-  "resetCredentialsFlow": "reset credentials",
-  "clientAuthenticationFlow": "clients",
-  "dockerAuthenticationFlow": "docker auth",
-  "attributes": {
-    "cibaBackchannelTokenDeliveryMode": "poll",
-    "cibaExpiresIn": "120",
-    "cibaAuthRequestedUserHint": "login_hint",
-    "oauth2DeviceCodeLifespan": "600",
-    "clientOfflineSessionMaxLifespan": "0",
-    "oauth2DevicePollingInterval": "5",
-    "clientSessionIdleTimeout": "0",
-    "parRequestUriLifespan": "60",
-    "clientSessionMaxLifespan": "0",
-    "clientOfflineSessionIdleTimeout": "0",
-    "cibaInterval": "5",
-    "realmReusableOtpCode": "false"
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "TERMS_AND_CONDITIONS",
+    "name" : "Terms and Conditions",
+    "providerId" : "TERMS_AND_CONDITIONS",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  }, {
+    "alias" : "delete_account",
+    "name" : "Delete Account",
+    "providerId" : "delete_account",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 60,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register",
+    "name" : "Webauthn Register",
+    "providerId" : "webauthn-register",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 70,
+    "config" : { }
+  }, {
+    "alias" : "webauthn-register-passwordless",
+    "name" : "Webauthn Register Passwordless",
+    "providerId" : "webauthn-register-passwordless",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 80,
+    "config" : { }
+  }, {
+    "alias" : "update_user_locale",
+    "name" : "Update User Locale",
+    "providerId" : "update_user_locale",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 1000,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "cibaBackchannelTokenDeliveryMode" : "poll",
+    "cibaExpiresIn" : "120",
+    "cibaAuthRequestedUserHint" : "login_hint",
+    "oauth2DeviceCodeLifespan" : "600",
+    "clientOfflineSessionMaxLifespan" : "0",
+    "oauth2DevicePollingInterval" : "5",
+    "clientSessionIdleTimeout" : "0",
+    "parRequestUriLifespan" : "60",
+    "clientSessionMaxLifespan" : "0",
+    "clientOfflineSessionIdleTimeout" : "0",
+    "cibaInterval" : "5",
+    "realmReusableOtpCode" : "false"
   },
-  "keycloakVersion": "22.0.1",
-  "userManagedAccessAllowed": false,
-  "clientProfiles": {
-    "profiles": []
+  "keycloakVersion" : "23.0.7",
+  "userManagedAccessAllowed" : false,
+  "clientProfiles" : {
+    "profiles" : [ ]
   },
-  "clientPolicies": {
-    "policies": []
+  "clientPolicies" : {
+    "policies" : [ ]
   }
 }

--- a/keycloak/import/collectivo-users-0.json
+++ b/keycloak/import/collectivo-users-0.json
@@ -1,0 +1,92 @@
+{
+  "realm" : "collectivo",
+  "users" : [ {
+    "id" : "49bfa679-4393-4f51-b372-c12cc40ed085",
+    "createdTimestamp" : 1697096551946,
+    "username" : "admin@example.com",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Admin",
+    "lastName" : "Example",
+    "email" : "admin@example.com",
+    "credentials" : [ {
+      "id" : "c082252b-8bb2-4882-93d6-911c6cf5320e",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1697096569039,
+      "secretData" : "{\"value\":\"zkatZx0E/bGR33MCsgo+ZjyFbaR9on8p1yxuDtwsMLM=\",\"salt\":\"OODcXFn3qUvbSYfrqiDe3g==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-collectivo" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "7c18a9d7-e508-41ef-8c15-191562fc6291",
+    "createdTimestamp" : 1700059405993,
+    "username" : "editor@example.com",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "Editor",
+    "lastName" : "Example",
+    "email" : "editor@example.com",
+    "credentials" : [ {
+      "id" : "7dc97ef7-08e5-40fb-a341-7536e36f2f00",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1700059417104,
+      "secretData" : "{\"value\":\"HT2OBSqKBz+GbrEypScJHlEZAVmIcjLy5hEyDhj81yk=\",\"salt\":\"1LNj+oXZOId69zHb/hIxxA==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-collectivo" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "beaf498c-a994-44ff-b4cb-cbf0710ca0d0",
+    "createdTimestamp" : 1703688693500,
+    "username" : "service-account-admin-cli",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "serviceAccountClientId" : "admin-cli",
+    "credentials" : [ ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access", "uma_authorization", "default-roles-collectivo" ],
+    "clientRoles" : {
+      "realm-management" : [ "view-realm", "manage-events", "manage-authorization", "query-clients", "view-users", "realm-admin", "view-events", "manage-realm", "create-client", "view-clients", "view-authorization", "view-identity-providers", "manage-identity-providers", "impersonation", "query-groups", "query-users", "manage-users", "manage-clients", "query-realms" ],
+      "broker" : [ "read-token" ],
+      "account" : [ "view-profile", "manage-account", "delete-account", "manage-consent", "view-applications", "view-groups", "view-consent", "manage-account-links" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "1f0042d1-9a1b-4b41-b39e-4d135e60856c",
+    "createdTimestamp" : 1697096484471,
+    "username" : "user@example.com",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : true,
+    "firstName" : "User",
+    "lastName" : "Example",
+    "email" : "user@example.com",
+    "credentials" : [ {
+      "id" : "5b597453-edf7-42f6-b425-9cef425d41c2",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1697096532500,
+      "secretData" : "{\"value\":\"fgGniieuvQiWTebHCsbK1teYLljLdAkxqC342JoypVk=\",\"salt\":\"CsW3KFF8XZ9eW5KV0+W/QQ==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-collectivo" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ]
+}

--- a/nextcloud/README.md
+++ b/nextcloud/README.md
@@ -1,0 +1,65 @@
+# Nextcloud
+
+[Admin manual](https://docs.nextcloud.com/server/stable/admin_manual/)
+
+## Apps
+
+- Login with the admin user you created.
+- Install apps
+  - in production
+    - [OpenID Connect user backend](https://github.com/nextcloud/user_oidc)
+    - [Calendar](https://github.com/nextcloud/calendar/)
+    - [Forms](https://github.com/nextcloud/forms)
+    - [Nextcloud Office](https://collaboraoffice.com/)
+  - testing
+    - [Deck](https://github.com/nextcloud/deck)
+    - [Talk](https://github.com/nextcloud/spreed) ([documentation](https://nextcloud-talk.readthedocs.io/en/latest/quick-install/))
+    - [Two-factor authentication](https://github.com/nextcloud/twofactor_totp)
+- Configure OpenID Connect app
+  - Allow Nextcloud to [make requests to servers on the LAN](https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/config_sample_php_parameters.html#allow-local-remote-servers) so it can reach Keycloak.
+  ```
+  docker exec -u www-data nextcloud php /var/www/html/occ config:system:set allow_local_remote_servers --value=true --type=boolean
+  ```
+  - Allow the OIDC app to [send secrets over http in plain text](https://github.com/nextcloud/user_oidc#allow-login-over-unencrypted-http)
+  ```
+  docker exec -u www-data nextcloud php /var/www/html/occ config:app:set --value=1 --type=boolean user_oidc allow_insecure_http
+  ```
+  - Go to Admin settings > OpenID Connect > Register
+    - Identifier: anything descriptive, e.g. `Keycloak`
+    - Client ID: `nextcloud` (as defined in the [collectivo realm](../keycloak/import/collectivo-realm.json))
+    - Client Secret: empty
+    - Discovery endpoint:
+    ```
+    http://keycloak:8080/realms/collectivo/.well-known/openid-configuration
+    ```
+  - You can now login with the test users as for directus
+
+## [Redirect to keycloak login](https://github.com/nextcloud/user_oidc?tab=readme-ov-file#disable-other-login-methods)
+
+You can disable other logins methods if login is only possible via OIDC (as is the case in production). In case OIDC breaks, admins can still login by appending `?direct=1` to the URL, e.g. at [http://localhost:8081/login?direct=1](http://localhost:8081/login?direct=1).
+
+```
+docker exec -u www-data nextcloud php /var/www/html/occ config:app:set --value=0 --type=string user_oidc allow_multiple_user_backends
+```
+
+## Troubleshooting
+
+Watch the logs
+```
+docker exec -u www-data nextcloud php /var/www/html/occ log:watch
+```
+
+Check whether Nextcloud can reach Keycloak
+```
+docker compose exec nextcloud curl http://keycloak:8080/realms/collectivo/.well-known/openid-configuration
+```
+
+Check settings in `config.php`, e.g. trusted_domains
+```
+docker exec nextcloud cat /var/www/html/config/config.php
+```
+
+Reset
+```
+sudo rm -r nextcloud_data nextcloud_db_data
+```


### PR DESCRIPTION
- docker-compose.yml
  - add nextcloud and nextcloud-db services with profile ` nextcloud`
  - add keycloak service since the production config does not work in the dev setting. Changes include exposing port 8080, disabling strict hostname checks, and disabling the reverse proxy
  - add profile `keycloak` to keycloak and keycloak-db services so they do not need to be started manually
- add nextcloud client to keycloak collectivo realm and mv users to separate json. Tested import on keycloak startup.  
- readme
  - add nc section 
  - update keycloak user and setup
  - some formatting to make commands easier to copy
- add nc readme
- add keycloak readme

Closes #159 