### PR TITLE
show "Anmeldung entfernen" button for today's shifts in admin view

### DIFF
--- a/collectivo/app/components/shiftsViewer/ModalAdmin.vue
+++ b/collectivo/app/components/shiftsViewer/ModalAdmin.vue
@@ -44,6 +44,12 @@ const tomorrow = new Date(
   ),
 );
 const isPast = start.getTime() < tomorrow.getTime();
+const todayStart = new Date(
+  Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0),
+);
+const isToday =
+  start.getTime() >= todayStart.getTime() &&
+  start.getTime() < tomorrow.getTime();
 const runtimeConfig = useRuntimeConfig();
 
 const categories = useShiftsCategories();
@@ -402,7 +408,7 @@ function checkIfMshipInAssignments(mship: number) {
                     class="flex flex-col gap-2"
                   >
                     <UButton
-                      v-if="!isPast"
+                      v-if="!isPast || isToday"
                       icon="i-heroicons-trash-16-solid"
                       size="sm"
                       :label="t('Remove assignment')"


### PR DESCRIPTION
Previously, admins could only mark today's shifts as missed, leaving the slot occupied. Extending the existing Remove-assignment button's visibility (!isPast → !isPast || isToday) lets admins free up the slot on the day of the shift so others can sign up.

solves #152